### PR TITLE
Add profile email update and requester info

### DIFF
--- a/src/backend/DailyFitness.Api/Controllers/UsersController.cs
+++ b/src/backend/DailyFitness.Api/Controllers/UsersController.cs
@@ -3,6 +3,7 @@ using DailyFitness.Api.Common.Extensions;
 using DailyFitness.Application.Dtos.Authentication;
 using DailyFitness.Application.Dtos.Users;
 using DailyFitness.Application.Interfaces.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DailyFitness.Api.Controllers;
@@ -67,12 +68,23 @@ public class UsersController(IUserService userService) : ControllerBase
         return result.ToActionResult(this);
     }
 
+    [Authorize]
     [HttpGet("get-profile/{userId:guid}")]
     public async Task<IActionResult> GetProfile(Guid userId, CancellationToken ct)
     {
         var loggedUserId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier) ?? "");
 
         var result = await userService.GetProfile(userId, loggedUserId, ct);
+        return result.ToActionResult(this);
+    }
+
+    [Authorize]
+    [HttpPut("update-profile/{userId:guid}")]
+    public async Task<IActionResult> UpdateProfile(Guid userId, UpdateProfileDto model, CancellationToken ct)
+    {
+        var loggedUserId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier) ?? "");
+
+        var result = await userService.UpdateProfile(userId, loggedUserId, model, ct);
         return result.ToActionResult(this);
     }
 }

--- a/src/backend/DailyFitness.Api/Program.cs
+++ b/src/backend/DailyFitness.Api/Program.cs
@@ -4,8 +4,6 @@ using DailyFitness.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-
 builder.AddLogging();
 builder.AddConfiguration();
 builder.AddDocumentation();
@@ -21,7 +19,6 @@ app.UsePathBase("/DailyFitness");
 app.UseCrossOrigin();
 app.UseGlobalExceptionHandler();
 
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment() || builder.Configuration["IsDevelopment"] == "Y")
     app.ConfigureDevEnvironment();
 

--- a/src/backend/DailyFitness.Application/Dtos/Professional/ProfessionalDto.cs
+++ b/src/backend/DailyFitness.Application/Dtos/Professional/ProfessionalDto.cs
@@ -1,4 +1,4 @@
-﻿using DailyFitness.Domain.Common;
+using DailyFitness.Domain.Common;
 using DailyFitness.Domain.Entities;
 
 namespace DailyFitness.Application.Dtos.Professional;
@@ -31,7 +31,7 @@ public class ProfessionalDto
         user.FirstName,
         user.Surname,
         user.Email,
-        user.ProfessionalRequests?.First().Biography ?? string.Empty,
-        user.ProfessionalRequests?.First().Specialization ?? string.Empty,
-        user.ProfessionalRequests?.First().Skills ?? string.Empty);
+        user.ProfessionalRequests?.First()?.Biography ?? string.Empty,
+        user.ProfessionalRequests?.First()?.Specialization ?? string.Empty,
+        user.ProfessionalRequests?.First()?.Skills ?? string.Empty);
 }

--- a/src/backend/DailyFitness.Application/Dtos/Professional/ProfessionalRequestDto.cs
+++ b/src/backend/DailyFitness.Application/Dtos/Professional/ProfessionalRequestDto.cs
@@ -1,4 +1,3 @@
-﻿using System.Runtime.InteropServices.ComTypes;
 using DailyFitness.Domain.Entities;
 using DailyFitness.Domain.ValueObjects;
 
@@ -7,6 +6,8 @@ namespace DailyFitness.Application.Dtos.Professional;
 public class ProfessionalRequestDto
 {
     public string Id { get; set; } = string.Empty;
+    public string UserName { get; set; }
+    public string UserEmail { get; set; }
     public string Biography { get; set; } = string.Empty;
     public string Specialization { get; set; } = string.Empty;
     public List<string> Skills { get; set; } = [];
@@ -19,11 +20,13 @@ public class ProfessionalRequestDto
     {
     }
 
-    public ProfessionalRequestDto(Guid id, string biography, string specialization, string skills,
+    public ProfessionalRequestDto(Guid id, string userName, string userEmail, string biography, string specialization, string skills,
         EProfessionalRequestStatus professionalRequestStatus, DateTime? evaluatedOn, string? evaluationComments,
         string? evaluatorFullName)
     {
         Id = id.ToString();
+        UserName = userName;
+        UserEmail = userEmail;
         Biography = biography;
         Specialization = specialization;
         Skills = skills.Split(',').ToList();
@@ -35,6 +38,8 @@ public class ProfessionalRequestDto
 
     public static ProfessionalRequestDto FromEntity(ProfessionalRequest request)
         => new(request.Id,
+            $"{request.User!.FirstName} {request.User!.Surname}",
+            request.User!.Email,
             request.Biography,
             request.Specialization,
             request.Skills,

--- a/src/backend/DailyFitness.Application/Dtos/Users/UpdateProfileDto.cs
+++ b/src/backend/DailyFitness.Application/Dtos/Users/UpdateProfileDto.cs
@@ -1,0 +1,6 @@
+namespace DailyFitness.Application.Dtos.Users;
+
+public class UpdateProfileDto
+{
+    public string Email { get; set; } = string.Empty;
+}

--- a/src/backend/DailyFitness.Application/Interfaces/Repositories/IUserRepository.cs
+++ b/src/backend/DailyFitness.Application/Interfaces/Repositories/IUserRepository.cs
@@ -5,6 +5,7 @@ namespace DailyFitness.Application.Interfaces.Repositories;
 public interface IUserRepository : IRepository<User>
 {
     Task<bool> GetIfAlreadyExist(string email, CancellationToken ct);
+    Task<bool> EmailExistsForAnotherUser(string email, Guid excludeUserId, CancellationToken ct);
     Task<User?> GetByEmail(string email, CancellationToken ct);
     Task AddResetPasswordRequest(ResetPasswordRequest request, CancellationToken ct);
     Task<ResetPasswordRequest?> GetActiveResetPasswordRequestWithUserByToken(string token, CancellationToken ct);

--- a/src/backend/DailyFitness.Application/Interfaces/Services/IUserService.cs
+++ b/src/backend/DailyFitness.Application/Interfaces/Services/IUserService.cs
@@ -11,4 +11,5 @@ public interface IUserService
     Task<ResultDto<string>> ResetPasswordRequest(ResetUserPasswordRequestDto model, string frontendUrl, CancellationToken cancellationToken);
     Task<ResultDto<UserDto>> ResetPassword(ResetUserPasswordDto model, CancellationToken cancellationToken);
     Task<ResultDto<ProfileDto>> GetProfile(Guid userId, Guid loggedUserId, CancellationToken cancellationToken);
+    Task<ResultDto<ProfileDto>> UpdateProfile(Guid userId, Guid loggedUserId, UpdateProfileDto model, CancellationToken cancellationToken);
 }

--- a/src/backend/DailyFitness.Application/Services/UserService.cs
+++ b/src/backend/DailyFitness.Application/Services/UserService.cs
@@ -1,4 +1,4 @@
-﻿using DailyFitness.Application.Common.Results;
+using DailyFitness.Application.Common.Results;
 using DailyFitness.Application.Dtos.Authentication;
 using DailyFitness.Application.Dtos.Users;
 using DailyFitness.Application.Interfaces.Repositories;
@@ -81,7 +81,7 @@ public class UserService(
 
         await userRepository.AddResetPasswordRequest(request, cancellationToken);
 
-        await emailService.SendResetPasswordEmail(user,$"{frontendUrl}/account/reset-password?token={request.Token}", cancellationToken);
+        await emailService.SendResetPasswordEmail(user,$"{frontendUrl}/reset-password?token={request.Token}", cancellationToken);
 
         return ResultDto<string>.Ok(request.Token, "Solicitação de redefinição de senha enviada com sucesso");
     }
@@ -122,5 +122,31 @@ public class UserService(
         return user is not null
             ? ResultDto<ProfileDto>.Ok(ProfileDto.FromEntity(user), "Perfil obtido com sucesso")
             : ResultDto<ProfileDto>.Fail("Falha de validação", ["Usuário não encontrado"]);
+    }
+
+    public async Task<ResultDto<ProfileDto>> UpdateProfile(Guid userId, Guid loggedUserId, UpdateProfileDto model, CancellationToken cancellationToken)
+    {
+        if(userId != loggedUserId)
+            return ResultDto<ProfileDto>.Fail("Falha de validação", ["Acesso não autorizado!"]);
+
+        var validationResult = ExecuteValidation(new UpdateProfileDtoValidator(), model);
+
+        if(!validationResult.IsValid)
+            return ResultDto<ProfileDto>.Fail("Falha de validação", validationResult.Errors.Select(x => x.ErrorMessage).ToList());
+
+        var user = await userRepository.Get(userId, cancellationToken);
+
+        if(user == null)
+            return ResultDto<ProfileDto>.Fail("Falha de validação", ["Usuário não encontrado"]);
+
+        if(await userRepository.EmailExistsForAnotherUser(model.Email, userId, cancellationToken))
+            return ResultDto<ProfileDto>.Fail("Falha de validação", ["E-mail já está em uso por outro usuário"]);
+
+        user.UpdateEmail(model.Email);
+
+        userRepository.Update(user);
+        await userRepository.SaveChanges(cancellationToken);
+
+        return ResultDto<ProfileDto>.Ok(ProfileDto.FromEntity(user), "Perfil atualizado com sucesso");
     }
 }

--- a/src/backend/DailyFitness.Application/Validators/Users/UpdateProfileDtoValidator.cs
+++ b/src/backend/DailyFitness.Application/Validators/Users/UpdateProfileDtoValidator.cs
@@ -1,0 +1,15 @@
+using DailyFitness.Application.Dtos.Users;
+using FluentValidation;
+
+namespace DailyFitness.Application.Validators.Users;
+
+public class UpdateProfileDtoValidator : AbstractValidator<UpdateProfileDto>
+{
+    public UpdateProfileDtoValidator()
+    {
+        RuleFor(x => x.Email)
+            .NotEmpty().WithMessage("O e-mail é obrigatório.")
+            .MaximumLength(255).WithMessage("O e-mail deve ter no máximo 255 caracteres.")
+            .EmailAddress().WithMessage("O e-mail informado é inválido.");
+    }
+}

--- a/src/backend/DailyFitness.Domain/Entities/User.cs
+++ b/src/backend/DailyFitness.Domain/Entities/User.cs
@@ -44,6 +44,12 @@ public class User : Entity
         Surname = surname;
     }
 
+    public void UpdateEmail(string email)
+    {
+        Email = email;
+        UpdatedAt = DateTime.Now;
+    }
+
     public void UpdatePassword(string passwordHash) => PasswordHash = passwordHash;
 
     public void UpdateLastLoginAt() => LastLoginAt = DateTime.Now;

--- a/src/backend/DailyFitness.Infrastructure/Repositories/UserRepository.cs
+++ b/src/backend/DailyFitness.Infrastructure/Repositories/UserRepository.cs
@@ -16,6 +16,11 @@ public class UserRepository(AppDbContext context) : Repository<User>(context), I
         return await set.AnyAsync(x => x.Email.ToLower() == email.ToLower(), ct);
     }
 
+    public async Task<bool> EmailExistsForAnotherUser(string email, Guid excludeUserId, CancellationToken ct)
+    {
+        return await set.AnyAsync(x => x.Email.ToLower() == email.ToLower() && x.Id != excludeUserId, ct);
+    }
+
     public async Task<User?> GetByEmail(string email, CancellationToken ct)
     {
         return await set.FirstOrDefaultAsync(x => x.Email.ToLower() == email.ToLower(), ct);

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -58,8 +58,6 @@ export interface ProfileData {
 export type ProfileResponse = ApiResponse<ProfileData>;
 
 export interface UpdateProfileRequest {
-  firstname: string;
-  surname: string;
   email: string;
 }
 

--- a/src/frontend/src/lib/professionals-api.ts
+++ b/src/frontend/src/lib/professionals-api.ts
@@ -33,6 +33,8 @@ export const ProfessionalRequestStatusLabel: Record<EProfessionalRequestStatus, 
 
 export interface ProfessionalRequestDto {
   id: string;
+  userName: string;
+  userEmail: string;
   biography: string;
   specialization: string;
   skills: string[];

--- a/src/frontend/src/pages/EditProfile.tsx
+++ b/src/frontend/src/pages/EditProfile.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { ArrowLeft, Loader2, Save, AlertCircle, CheckCircle2 } from "lucide-react";
+import { ArrowLeft, Loader2, Save, AlertCircle, CheckCircle2, User as UserIcon, Mail, Lock } from "lucide-react";
 import DashboardHeader from "@/components/DashboardHeader";
 import { getProfile, updateProfile } from "@/lib/api";
-import { getToken, getUser, saveAuth } from "@/lib/auth";
+import { clearAuth, getUser } from "@/lib/auth";
 
 const EditProfile = () => {
   const navigate = useNavigate();
@@ -48,42 +48,29 @@ const EditProfile = () => {
     setError("");
     setSuccess("");
 
-    const fn = firstname.trim();
-    const sn = surname.trim();
     const em = email.trim();
 
-    if (!fn || !sn || !em) {
-      setError("Preencha todos os campos.");
+    if (!em) {
+      setError("O e-mail é obrigatório.");
       return;
     }
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(em)) {
-      setError("Email inválido.");
+      setError("E-mail inválido.");
       return;
     }
 
     setSaving(true);
     try {
-      const res = await updateProfile(authUser.id, {
-        firstname: fn,
-        surname: sn,
-        email: em,
-      });
+      await updateProfile(authUser.id, { email: em });
 
-      // Atualiza dados em cache (mantém o token atual)
-      const token = getToken();
-      if (token) {
-        saveAuth(token, {
-          ...authUser,
-          name: `${fn} ${sn}`.trim(),
-          email: em,
-        });
-      }
+      setSuccess("E-mail atualizado com sucesso! Você será redirecionado para o login.");
 
-      setSuccess(res.message || "Perfil atualizado com sucesso.");
-      setTimeout(() => navigate("/perfil"), 900);
+      setTimeout(() => {
+        clearAuth();
+        navigate("/login");
+      }, 2000);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Erro ao atualizar perfil.");
-    } finally {
       setSaving(false);
     }
   };
@@ -104,7 +91,7 @@ const EditProfile = () => {
         <div className="glass-card rounded-2xl p-8">
           <h2 className="text-2xl font-semibold mb-1">Editar Perfil</h2>
           <p className="text-sm text-muted-foreground mb-6">
-            Atualize suas informações pessoais
+            Atualize seu endereço de e-mail
           </p>
 
           {loading ? (
@@ -114,30 +101,48 @@ const EditProfile = () => {
             </div>
           ) : (
             <form onSubmit={handleSubmit} className="space-y-5">
+
+              {/* Campos somente leitura */}
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <Field
+                <ReadOnlyField
                   label="Nome"
-                  value={firstname}
-                  onChange={setFirstname}
-                  placeholder="Seu nome"
-                  disabled={saving}
+                  value={firstname || "—"}
+                  icon={<UserIcon className="w-4 h-4" />}
                 />
-                <Field
+                <ReadOnlyField
                   label="Sobrenome"
-                  value={surname}
-                  onChange={setSurname}
-                  placeholder="Seu sobrenome"
-                  disabled={saving}
+                  value={surname || "—"}
+                  icon={<UserIcon className="w-4 h-4" />}
                 />
               </div>
-              <Field
-                label="E-mail"
-                type="email"
-                value={email}
-                onChange={setEmail}
-                placeholder="voce@email.com"
-                disabled={saving}
-              />
+
+              <div className="h-px bg-border" />
+
+              {/* Campo editável */}
+              <div>
+                <label className="block">
+                  <span className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1.5">
+                    <Mail className="w-3.5 h-3.5" />
+                    Novo e-mail
+                  </span>
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder="voce@email.com"
+                    disabled={saving}
+                    autoComplete="email"
+                    className="w-full rounded-xl border border-border bg-secondary/40 px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary/60 transition-all disabled:opacity-60"
+                  />
+                </label>
+              </div>
+
+              <div className="rounded-xl border border-border bg-secondary/20 px-4 py-3 flex items-start gap-2 text-xs text-muted-foreground">
+                <Lock className="w-3.5 h-3.5 shrink-0 mt-0.5" />
+                <span>
+                  Ao alterar o e-mail, sua sessão será encerrada e você precisará fazer login novamente com o novo endereço.
+                </span>
+              </div>
 
               {error && (
                 <div className="rounded-xl bg-destructive/10 border border-destructive/30 px-4 py-3 text-sm text-destructive flex items-start gap-3">
@@ -165,7 +170,7 @@ const EditProfile = () => {
                   ) : (
                     <Save className="w-4 h-4" />
                   )}
-                  {saving ? "Salvando..." : "Salvar alterações"}
+                  {saving ? "Salvando..." : "Salvar e-mail"}
                 </button>
                 <Link
                   to="/perfil"
@@ -182,27 +187,20 @@ const EditProfile = () => {
   );
 };
 
-interface FieldProps {
+interface ReadOnlyFieldProps {
   label: string;
   value: string;
-  onChange: (v: string) => void;
-  placeholder?: string;
-  type?: string;
-  disabled?: boolean;
+  icon: React.ReactNode;
 }
 
-const Field = ({ label, value, onChange, placeholder, type = "text", disabled }: FieldProps) => (
-  <label className="block">
-    <span className="block text-xs text-muted-foreground mb-1.5">{label}</span>
-    <input
-      type={type}
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      placeholder={placeholder}
-      disabled={disabled}
-      className="w-full rounded-xl border border-border bg-secondary/40 px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary/60 transition-all disabled:opacity-60"
-    />
-  </label>
+const ReadOnlyField = ({ label, value, icon }: ReadOnlyFieldProps) => (
+  <div className="rounded-xl border border-border bg-secondary/20 px-4 py-3 opacity-70">
+    <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
+      {icon}
+      <span>{label}</span>
+    </div>
+    <p className="text-sm text-foreground">{value}</p>
+  </div>
 );
 
 export default EditProfile;

--- a/src/frontend/src/pages/professionals/admin/ProfessionalRequestDetail.tsx
+++ b/src/frontend/src/pages/professionals/admin/ProfessionalRequestDetail.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import {
   ArrowLeft, Loader2, AlertCircle, CheckCircle2, XCircle, Clock,
-  BookOpen, Briefcase, Tag, MessageSquare, User2, CalendarDays,
+  BookOpen, Briefcase, Tag, MessageSquare, User2, CalendarDays, Mail,
 } from "lucide-react";
 import DashboardHeader from "@/components/DashboardHeader";
 import {
@@ -123,6 +123,18 @@ const ProfessionalRequestDetail = () => {
               </div>
 
               <div className="h-px bg-border" />
+
+              <div className="rounded-xl border border-border bg-secondary/40 px-4 py-4 space-y-2">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-3">Solicitante</p>
+                <div className="flex items-center gap-2 text-sm">
+                  <User2 className="w-4 h-4 text-muted-foreground shrink-0" />
+                  <span className="text-foreground font-medium">{request.userName || "Não identificado"}</span>
+                </div>
+                <div className="flex items-center gap-2 text-sm">
+                  <Mail className="w-4 h-4 text-muted-foreground shrink-0" />
+                  <span className="text-muted-foreground">{request.userEmail}</span>
+                </div>
+              </div>
 
               <InfoSection icon={<Briefcase className="w-4 h-4" />} title="Especialização" content={request.specialization || "Não informado"} />
               <InfoSection icon={<BookOpen className="w-4 h-4" />} title="Biografia" content={request.biography || "Não informado"} multiline />

--- a/src/frontend/src/pages/professionals/admin/ProfessionalRequestsList.tsx
+++ b/src/frontend/src/pages/professionals/admin/ProfessionalRequestsList.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { ArrowLeft, Loader2, AlertCircle, RefreshCw, ClipboardList, Clock, CheckCircle2, XCircle, ChevronRight } from "lucide-react";
+import { ArrowLeft, Loader2, AlertCircle, RefreshCw, ClipboardList, Clock, CheckCircle2, XCircle, ChevronRight, User2, Mail } from "lucide-react";
 import DashboardHeader from "@/components/DashboardHeader";
 import { getAllProfessionalRequests, ProfessionalRequestDto, EProfessionalRequestStatus, ProfessionalRequestStatusLabel } from "@/lib/professionals-api";
 
@@ -125,9 +125,16 @@ const RequestRow = ({ request, statusIcon, statusStyle }: RequestRowProps) => {
       <div className="flex items-center gap-4 min-w-0">
         {statusIcon[status]}
         <div className="min-w-0">
-          <p className="text-sm font-medium text-foreground truncate">{request.specialization || "Especialização não informada"}</p>
-          <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
-            {request.biography?.slice(0, 80)}{(request.biography?.length ?? 0) > 80 ? "..." : ""}
+          <div className="flex items-center gap-1.5 min-w-0">
+            <User2 className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+            <p className="text-sm font-medium text-foreground truncate">{request.userName || "Usuário não identificado"}</p>
+          </div>
+          <div className="flex items-center gap-1.5 mt-0.5 min-w-0">
+            <Mail className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+            <p className="text-xs text-muted-foreground truncate">{request.userEmail}</p>
+          </div>
+          <p className="text-xs text-muted-foreground/70 mt-1 line-clamp-1">
+            {request.specialization || "Especialização não informada"}
           </p>
         </div>
       </div>


### PR DESCRIPTION
Backend: Add UpdateProfile flow (UpdateProfileDto, validator, IUserService.UpdateProfile, UserService.UpdateProfile) with authorization, email uniqueness check (IUserRepository.EmailExistsForAnotherUser), User.UpdateEmail, and new controller PUT /update-profile. Also fix reset-password frontend URL and make Professional DTO null-safe; add userName/userEmail to ProfessionalRequestDto and repository support. Frontend: EditProfile simplified to only update email (clears auth and forces re-login), update API/types for update request and professional DTOs, and show requester name/email in professional requests list/detail. Misc: minor Program.cs cleanup.