### PR TITLE
Add training plans feature (backend + frontend)

### DIFF
--- a/src/backend/DailyFitness.Api/Controllers/TrainingPlansController.cs
+++ b/src/backend/DailyFitness.Api/Controllers/TrainingPlansController.cs
@@ -1,0 +1,321 @@
+using System.Security.Claims;
+using DailyFitness.Api.Common.Extensions;
+using DailyFitness.Application.Dtos.TrainingPlan;
+using DailyFitness.Application.Interfaces.Services;
+using DailyFitness.Domain.ValueObjects;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DailyFitness.Api.Controllers;
+
+/// <summary>
+/// Controller responsible for training plan operations available to regular users.
+/// </summary>
+[ApiController, Authorize]
+[Route("[controller]")]
+public class TrainingPlansController(ITrainingPlanService trainingPlanService) : ControllerBase
+{
+    // ── Public listing ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Lists all active training plans. Optional filters: objective and level.
+    /// </summary>
+    [HttpGet]
+    public async Task<IActionResult> GetAvailablePlans(
+        [FromQuery] ETrainingObjective? objective,
+        [FromQuery] ETrainingLevel? level,
+        CancellationToken ct)
+    {
+        var result = await trainingPlanService.GetAvailablePlans(objective, level, ct);
+        return result.ToActionResult(this);
+    }
+
+    /// <summary>
+    /// Retrieves details of a specific training plan.
+    /// </summary>
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetPlanDetail(Guid id, CancellationToken ct)
+    {
+        var result = await trainingPlanService.GetPlanDetail(id, ct);
+        return result.ToActionResult(this);
+    }
+
+    // ── Subscription ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Subscribes the authenticated user to a training plan.
+    /// The user must not have another active plan.
+    /// </summary>
+    [HttpPost("{id:guid}/subscribe")]
+    public async Task<IActionResult> SubscribePlan(Guid id, CancellationToken ct)
+    {
+        var userId = GetUserId();
+        var result = await trainingPlanService.SubscribePlan(id, userId, ct);
+        return result.ToActionResult(this);
+    }
+
+    // ── Current Plan ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Retrieves the authenticated user's currently active training plan.
+    /// </summary>
+    [HttpGet("current")]
+    public async Task<IActionResult> GetCurrentPlan(CancellationToken ct)
+    {
+        var userId = GetUserId();
+        var result = await trainingPlanService.GetCurrentPlan(userId, ct);
+        return result.ToActionResult(this);
+    }
+
+    /// <summary>
+    /// Retrieves progress details of the authenticated user's active plan.
+    /// </summary>
+    [HttpGet("current/progress")]
+    public async Task<IActionResult> GetCurrentPlanProgress(CancellationToken ct)
+    {
+        var userId = GetUserId();
+        var result = await trainingPlanService.GetCurrentPlanProgress(userId, ct);
+        return result.ToActionResult(this);
+    }
+
+    /// <summary>
+    /// Cancels the authenticated user's active plan subscription, preserving history.
+    /// </summary>
+    [HttpPost("current/cancel")]
+    public async Task<IActionResult> CancelSubscription(CancelTrainingPlanDto model, CancellationToken ct)
+    {
+        var userId = GetUserId();
+        var result = await trainingPlanService.CancelSubscription(userId, model, ct);
+        return result.ToActionResult(this);
+    }
+
+    /// <summary>
+    /// Marks a workout item as completed for the current day.
+    /// Prevents duplicate marking of the same item on the same day.
+    /// </summary>
+    [HttpPost("current/workouts/{workoutId:guid}/items/{itemId:guid}/complete")]
+    public async Task<IActionResult> MarkItemProgress(Guid workoutId, Guid itemId, MarkTrainingItemProgressDto model, CancellationToken ct)
+    {
+        var userId = GetUserId();
+        var result = await trainingPlanService.MarkItemProgress(userId, workoutId, itemId, model, ct);
+        return result.ToActionResult(this);
+    }
+
+    /// <summary>
+    /// Finishes today's workout session when all required items have been completed.
+    /// </summary>
+    [HttpPost("current/workouts/{workoutId:guid}/finish-day")]
+    public async Task<IActionResult> FinishWorkoutDay(Guid workoutId, CancellationToken ct)
+    {
+        var userId = GetUserId();
+        var result = await trainingPlanService.FinishWorkoutDay(userId, workoutId, ct);
+        return result.ToActionResult(this);
+    }
+
+    // ── History ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns the full training plan history of the authenticated user (active, cancelled, completed).
+    /// </summary>
+    [HttpGet("history")]
+    public async Task<IActionResult> GetHistory(CancellationToken ct)
+    {
+        var userId = GetUserId();
+        var result = await trainingPlanService.GetHistory(userId, ct);
+        return result.ToActionResult(this);
+    }
+
+    // ── Admin — Management ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Lists all training plans. Restricted to administrators.
+    /// </summary>
+    [Authorize(Roles = "Administrator")]
+    [HttpGet("management")]
+    public async Task<IActionResult> GetAllPlans(CancellationToken ct)
+    {
+        var result = await trainingPlanService.GetAllPlans(ct);
+        return result.ToActionResult(this);
+    }
+
+    /// <summary>
+    /// Retrieves a specific training plan with full details. Restricted to administrators.
+    /// </summary>
+    [Authorize(Roles = "Administrator")]
+    [HttpGet("management/{id:guid}")]
+    public async Task<IActionResult> GetPlan(Guid id, CancellationToken ct)
+    {
+        var result = await trainingPlanService.GetPlan(id, ct);
+        return result.ToActionResult(this);
+    }
+
+    /// <summary>
+    /// Creates a new training plan. Restricted to administrators.
+    /// </summary>
+    [Authorize(Roles = "Administrator")]
+    [HttpPost("management")]
+    public async Task<IActionResult> CreatePlan(CreateTrainingPlanDto model, CancellationToken ct)
+    {
+        var userId = GetUserId();
+        var result = await trainingPlanService.CreatePlan(model, userId, ct);
+        return result.ToActionResult(this);
+    }
+
+    /// <summary>
+    /// Updates a training plan. Restricted to administrators.
+    /// </summary>
+    [Authorize(Roles = "Administrator")]
+    [HttpPut("management/{id:guid}")]
+    public async Task<IActionResult> UpdatePlan(Guid id, UpdateTrainingPlanDto model, CancellationToken ct)
+    {
+        var result = await trainingPlanService.UpdatePlan(id, model, ct);
+        return result.ToActionResult(this);
+    }
+
+    /// <summary>
+    /// Activates a training plan. Restricted to administrators.
+    /// </summary>
+    [Authorize(Roles = "Administrator")]
+    [HttpPatch("management/{id:guid}/activate")]
+    public async Task<IActionResult> ActivatePlan(Guid id, CancellationToken ct)
+    {
+        var result = await trainingPlanService.ActivatePlan(id, ct);
+        return result.ToActionResult(this);
+    }
+
+    /// <summary>
+    /// Deactivates a training plan. Restricted to administrators.
+    /// </summary>
+    [Authorize(Roles = "Administrator")]
+    [HttpPatch("management/{id:guid}/deactivate")]
+    public async Task<IActionResult> DeactivatePlan(Guid id, CancellationToken ct)
+    {
+        var result = await trainingPlanService.DeactivatePlan(id, ct);
+        return result.ToActionResult(this);
+    }
+
+    /// <summary>
+    /// Lists all subscribers of a training plan. Restricted to administrators.
+    /// </summary>
+    [Authorize(Roles = "Administrator")]
+    [HttpGet("management/{id:guid}/subscribers")]
+    public async Task<IActionResult> GetPlanSubscribers(Guid id, CancellationToken ct)
+    {
+        var result = await trainingPlanService.GetPlanSubscribers(id, ct);
+        return result.ToActionResult(this);
+    }
+
+    /// <summary>
+    /// Returns the progress of a specific subscriber. Restricted to administrators.
+    /// </summary>
+    [Authorize(Roles = "Administrator")]
+    [HttpGet("management/{id:guid}/subscribers/{userId:guid}/progress")]
+    public async Task<IActionResult> GetSubscriberProgress(Guid id, Guid userId, CancellationToken ct)
+    {
+        var result = await trainingPlanService.GetSubscriberProgress(id, userId, ct);
+        return result.ToActionResult(this);
+    }
+
+    // ── Professional — Management ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Lists all training plans created by the authenticated professional.
+    /// </summary>
+    [Authorize(Roles = "Professional")]
+    [HttpGet("managed")]
+    public async Task<IActionResult> GetManagedPlans(CancellationToken ct)
+    {
+        var userId = GetUserId();
+        var result = await trainingPlanService.GetManagedPlans(userId, ct);
+        return result.ToActionResult(this);
+    }
+
+    /// <summary>
+    /// Retrieves a specific plan created by the authenticated professional.
+    /// </summary>
+    [Authorize(Roles = "Professional")]
+    [HttpGet("managed/{id:guid}")]
+    public async Task<IActionResult> GetManagedPlan(Guid id, CancellationToken ct)
+    {
+        var userId = GetUserId();
+        var result = await trainingPlanService.GetManagedPlan(id, userId, ct);
+        return result.ToActionResult(this);
+    }
+
+    /// <summary>
+    /// Creates a new training plan as the authenticated professional.
+    /// </summary>
+    [Authorize(Roles = "Professional")]
+    [HttpPost("managed")]
+    public async Task<IActionResult> CreateManagedPlan(CreateTrainingPlanDto model, CancellationToken ct)
+    {
+        var userId = GetUserId();
+        var result = await trainingPlanService.CreateManagedPlan(model, userId, ct);
+        return result.ToActionResult(this);
+    }
+
+    /// <summary>
+    /// Updates a training plan created by the authenticated professional.
+    /// </summary>
+    [Authorize(Roles = "Professional")]
+    [HttpPut("managed/{id:guid}")]
+    public async Task<IActionResult> UpdateManagedPlan(Guid id, UpdateTrainingPlanDto model, CancellationToken ct)
+    {
+        var userId = GetUserId();
+        var result = await trainingPlanService.UpdateManagedPlan(id, model, userId, ct);
+        return result.ToActionResult(this);
+    }
+
+    /// <summary>
+    /// Activates a plan created by the authenticated professional.
+    /// </summary>
+    [Authorize(Roles = "Professional")]
+    [HttpPatch("managed/{id:guid}/activate")]
+    public async Task<IActionResult> ActivateManagedPlan(Guid id, CancellationToken ct)
+    {
+        var userId = GetUserId();
+        var result = await trainingPlanService.ActivateManagedPlan(id, userId, ct);
+        return result.ToActionResult(this);
+    }
+
+    /// <summary>
+    /// Deactivates a plan created by the authenticated professional.
+    /// </summary>
+    [Authorize(Roles = "Professional")]
+    [HttpPatch("managed/{id:guid}/deactivate")]
+    public async Task<IActionResult> DeactivateManagedPlan(Guid id, CancellationToken ct)
+    {
+        var userId = GetUserId();
+        var result = await trainingPlanService.DeactivateManagedPlan(id, userId, ct);
+        return result.ToActionResult(this);
+    }
+
+    /// <summary>
+    /// Lists subscribers of a plan created by the authenticated professional.
+    /// </summary>
+    [Authorize(Roles = "Professional")]
+    [HttpGet("managed/{id:guid}/subscribers")]
+    public async Task<IActionResult> GetManagedPlanSubscribers(Guid id, CancellationToken ct)
+    {
+        var userId = GetUserId();
+        var result = await trainingPlanService.GetManagedPlanSubscribers(id, userId, ct);
+        return result.ToActionResult(this);
+    }
+
+    /// <summary>
+    /// Returns progress of a subscriber in a plan created by the authenticated professional.
+    /// </summary>
+    [Authorize(Roles = "Professional")]
+    [HttpGet("managed/{id:guid}/subscribers/{subscriberUserId:guid}/progress")]
+    public async Task<IActionResult> GetManagedSubscriberProgress(Guid id, Guid subscriberUserId, CancellationToken ct)
+    {
+        var userId = GetUserId();
+        var result = await trainingPlanService.GetManagedSubscriberProgress(id, subscriberUserId, userId, ct);
+        return result.ToActionResult(this);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private Guid GetUserId() =>
+        Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier) ?? "");
+}

--- a/src/backend/DailyFitness.Application/DependencyInjection.cs
+++ b/src/backend/DailyFitness.Application/DependencyInjection.cs
@@ -20,6 +20,7 @@ public static class DependencyInjection
             services.AddScoped<IUserService, UserService>();
             services.AddScoped<IProfessionalService, ProfessionalService>();
             services.AddScoped<IChallengeService, ChallengeService>();
+            services.AddScoped<ITrainingPlanService, TrainingPlanService>();
         }
 
         private void AddValidation()

--- a/src/backend/DailyFitness.Application/Dtos/TrainingPlan/CancelTrainingPlanDto.cs
+++ b/src/backend/DailyFitness.Application/Dtos/TrainingPlan/CancelTrainingPlanDto.cs
@@ -1,0 +1,6 @@
+namespace DailyFitness.Application.Dtos.TrainingPlan;
+
+public class CancelTrainingPlanDto
+{
+    public string? Reason { get; set; }
+}

--- a/src/backend/DailyFitness.Application/Dtos/TrainingPlan/CreateTrainingPlanDto.cs
+++ b/src/backend/DailyFitness.Application/Dtos/TrainingPlan/CreateTrainingPlanDto.cs
@@ -1,0 +1,33 @@
+using DailyFitness.Domain.ValueObjects;
+
+namespace DailyFitness.Application.Dtos.TrainingPlan;
+
+public class CreateTrainingPlanDto
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public ETrainingObjective Objective { get; set; }
+    public ETrainingLevel Level { get; set; }
+    public string? Instructions { get; set; }
+    public int MinimumDurationDays { get; set; }
+    public List<CreateTrainingWorkoutDto> Workouts { get; set; } = [];
+}
+
+public class CreateTrainingWorkoutDto
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string? Instructions { get; set; }
+    public int Order { get; set; }
+    public List<CreateTrainingWorkoutItemDto> Items { get; set; } = [];
+}
+
+public class CreateTrainingWorkoutItemDto
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string? Instructions { get; set; }
+    public int? Sets { get; set; }
+    public int? Repetitions { get; set; }
+    public int Order { get; set; }
+}

--- a/src/backend/DailyFitness.Application/Dtos/TrainingPlan/MarkTrainingItemProgressDto.cs
+++ b/src/backend/DailyFitness.Application/Dtos/TrainingPlan/MarkTrainingItemProgressDto.cs
@@ -1,0 +1,7 @@
+namespace DailyFitness.Application.Dtos.TrainingPlan;
+
+public class MarkTrainingItemProgressDto
+{
+    // Data de referência — se null, usa hoje
+    public DateTime? ProgressDate { get; set; }
+}

--- a/src/backend/DailyFitness.Application/Dtos/TrainingPlan/TrainingPlanDto.cs
+++ b/src/backend/DailyFitness.Application/Dtos/TrainingPlan/TrainingPlanDto.cs
@@ -1,0 +1,86 @@
+using DailyFitness.Domain.Common;
+using DailyFitness.Domain.ValueObjects;
+
+namespace DailyFitness.Application.Dtos.TrainingPlan;
+
+public class TrainingPlanDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public ETrainingObjective Objective { get; set; }
+    public ETrainingLevel Level { get; set; }
+    public string? Instructions { get; set; }
+    public int MinimumDurationDays { get; set; }
+    public EntityStatus Status { get; set; }
+    public string? CreatedByUserId { get; set; }
+    public int SubscriberCount { get; set; }
+    public int ActiveSubscriberCount { get; set; }
+    public IEnumerable<TrainingWorkoutDto> Workouts { get; set; } = [];
+    public DateTime CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+
+    public static TrainingPlanDto FromEntity(Domain.Entities.TrainingPlan plan) => new()
+    {
+        Id = plan.Id.ToString(),
+        Name = plan.Name,
+        Description = plan.Description,
+        Objective = plan.Objective,
+        Level = plan.Level,
+        Instructions = plan.Instructions,
+        MinimumDurationDays = plan.MinimumDurationDays,
+        Status = plan.Status,
+        CreatedByUserId = plan.CreatedByUserId?.ToString(),
+        SubscriberCount = plan.UserTrainingPlans?.Count ?? 0,
+        ActiveSubscriberCount = plan.UserTrainingPlans?.Count(x => x.UserTrainingPlanStatus == EUserTrainingPlanStatus.Active) ?? 0,
+        Workouts = plan.Workouts?.Select(TrainingWorkoutDto.FromEntity) ?? [],
+        CreatedAt = plan.CreatedAt,
+        UpdatedAt = plan.UpdatedAt
+    };
+}
+
+public class TrainingWorkoutDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string? Instructions { get; set; }
+    public int Order { get; set; }
+    public EntityStatus Status { get; set; }
+    public IEnumerable<TrainingWorkoutItemDto> Items { get; set; } = [];
+
+    public static TrainingWorkoutDto FromEntity(Domain.Entities.TrainingWorkout workout) => new()
+    {
+        Id = workout.Id.ToString(),
+        Name = workout.Name,
+        Description = workout.Description,
+        Instructions = workout.Instructions,
+        Order = workout.Order,
+        Status = workout.Status,
+        Items = workout.Items?.Select(TrainingWorkoutItemDto.FromEntity) ?? []
+    };
+}
+
+public class TrainingWorkoutItemDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string? Instructions { get; set; }
+    public int? Sets { get; set; }
+    public int? Repetitions { get; set; }
+    public int Order { get; set; }
+    public EntityStatus Status { get; set; }
+
+    public static TrainingWorkoutItemDto FromEntity(Domain.Entities.TrainingWorkoutItem item) => new()
+    {
+        Id = item.Id.ToString(),
+        Name = item.Name,
+        Description = item.Description,
+        Instructions = item.Instructions,
+        Sets = item.Sets,
+        Repetitions = item.Repetitions,
+        Order = item.Order,
+        Status = item.Status
+    };
+}

--- a/src/backend/DailyFitness.Application/Dtos/TrainingPlan/UpdateTrainingPlanDto.cs
+++ b/src/backend/DailyFitness.Application/Dtos/TrainingPlan/UpdateTrainingPlanDto.cs
@@ -1,0 +1,35 @@
+using DailyFitness.Domain.ValueObjects;
+
+namespace DailyFitness.Application.Dtos.TrainingPlan;
+
+public class UpdateTrainingPlanDto
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public ETrainingObjective Objective { get; set; }
+    public ETrainingLevel Level { get; set; }
+    public string? Instructions { get; set; }
+    public int MinimumDurationDays { get; set; }
+    public List<UpsertTrainingWorkoutDto> Workouts { get; set; } = [];
+}
+
+public class UpsertTrainingWorkoutDto
+{
+    public Guid? Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string? Instructions { get; set; }
+    public int Order { get; set; }
+    public List<UpsertTrainingWorkoutItemDto> Items { get; set; } = [];
+}
+
+public class UpsertTrainingWorkoutItemDto
+{
+    public Guid? Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string? Instructions { get; set; }
+    public int? Sets { get; set; }
+    public int? Repetitions { get; set; }
+    public int Order { get; set; }
+}

--- a/src/backend/DailyFitness.Application/Dtos/TrainingPlan/UserTrainingPlanDto.cs
+++ b/src/backend/DailyFitness.Application/Dtos/TrainingPlan/UserTrainingPlanDto.cs
@@ -1,0 +1,128 @@
+using DailyFitness.Domain.ValueObjects;
+
+namespace DailyFitness.Application.Dtos.TrainingPlan;
+
+public class UserTrainingPlanDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string UserId { get; set; } = string.Empty;
+    public string UserFullName { get; set; } = string.Empty;
+    public string TrainingPlanId { get; set; } = string.Empty;
+    public string TrainingPlanName { get; set; } = string.Empty;
+    public EUserTrainingPlanStatus UserTrainingPlanStatus { get; set; }
+    public DateTime StartedAt { get; set; }
+    public DateTime? CancelledAt { get; set; }
+    public DateTime? CompletedAt { get; set; }
+    public string? CancellationReason { get; set; }
+    public TrainingPlanDto? TrainingPlan { get; set; }
+    public IEnumerable<UserTrainingProgressDto> Progresses { get; set; } = [];
+    public IEnumerable<UserTrainingWorkoutDailyLogDto> DailyLogs { get; set; } = [];
+    public decimal OverallProgressPercentage { get; set; }
+    public int TotalItemsCompleted { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+
+    public static UserTrainingPlanDto FromEntity(Domain.Entities.UserTrainingPlan utp) => new()
+    {
+        Id = utp.Id.ToString(),
+        UserId = utp.UserId.ToString(),
+        UserFullName = utp.User is not null ? $"{utp.User.FirstName} {utp.User.Surname}" : string.Empty,
+        TrainingPlanId = utp.TrainingPlanId.ToString(),
+        TrainingPlanName = utp.TrainingPlan?.Name ?? string.Empty,
+        UserTrainingPlanStatus = utp.UserTrainingPlanStatus,
+        StartedAt = utp.StartedAt,
+        CancelledAt = utp.CancelledAt,
+        CompletedAt = utp.CompletedAt,
+        CancellationReason = utp.CancellationReason,
+        TrainingPlan = utp.TrainingPlan is not null ? TrainingPlanDto.FromEntity(utp.TrainingPlan) : null,
+        Progresses = utp.Progresses?.Select(UserTrainingProgressDto.FromEntity) ?? [],
+        DailyLogs = utp.DailyLogs?.Select(UserTrainingWorkoutDailyLogDto.FromEntity) ?? [],
+        OverallProgressPercentage = CalculateOverallProgress(utp),
+        TotalItemsCompleted = utp.Progresses?.Count ?? 0,
+        CreatedAt = utp.CreatedAt,
+        UpdatedAt = utp.UpdatedAt
+    };
+
+    private static decimal CalculateOverallProgress(Domain.Entities.UserTrainingPlan utp)
+    {
+        if (utp.DailyLogs is null || !utp.DailyLogs.Any()) return 0m;
+
+        // Progresso geral: média dos percentuais dos daily logs
+        var avg = utp.DailyLogs.Average(x => x.ProgressPercentage);
+        return Math.Round(avg, 2);
+    }
+}
+
+public class UserTrainingProgressDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string UserTrainingPlanId { get; set; } = string.Empty;
+    public string TrainingWorkoutId { get; set; } = string.Empty;
+    public string TrainingWorkoutItemId { get; set; } = string.Empty;
+    public DateTime ProgressDate { get; set; }
+    public DateTime CompletedAt { get; set; }
+    public DateTime CreatedAt { get; set; }
+
+    public static UserTrainingProgressDto FromEntity(Domain.Entities.UserTrainingProgress progress) => new()
+    {
+        Id = progress.Id.ToString(),
+        UserTrainingPlanId = progress.UserTrainingPlanId.ToString(),
+        TrainingWorkoutId = progress.TrainingWorkoutId.ToString(),
+        TrainingWorkoutItemId = progress.TrainingWorkoutItemId.ToString(),
+        ProgressDate = progress.ProgressDate,
+        CompletedAt = progress.CompletedAt,
+        CreatedAt = progress.CreatedAt
+    };
+}
+
+public class UserTrainingWorkoutDailyLogDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string UserTrainingPlanId { get; set; } = string.Empty;
+    public string TrainingWorkoutId { get; set; } = string.Empty;
+    public DateTime ProgressDate { get; set; }
+    public decimal ProgressPercentage { get; set; }
+    public bool IsFinished { get; set; }
+    public DateTime? FinishedAt { get; set; }
+    public DateTime CreatedAt { get; set; }
+
+    public static UserTrainingWorkoutDailyLogDto FromEntity(Domain.Entities.UserTrainingWorkoutDailyLog log) => new()
+    {
+        Id = log.Id.ToString(),
+        UserTrainingPlanId = log.UserTrainingPlanId.ToString(),
+        TrainingWorkoutId = log.TrainingWorkoutId.ToString(),
+        ProgressDate = log.ProgressDate,
+        ProgressPercentage = log.ProgressPercentage,
+        IsFinished = log.IsFinished,
+        FinishedAt = log.FinishedAt,
+        CreatedAt = log.CreatedAt
+    };
+}
+
+public class TrainingPlanSubscriberDto
+{
+    public string UserTrainingPlanId { get; set; } = string.Empty;
+    public string UserId { get; set; } = string.Empty;
+    public string UserFullName { get; set; } = string.Empty;
+    public EUserTrainingPlanStatus Status { get; set; }
+    public DateTime StartedAt { get; set; }
+    public DateTime? CancelledAt { get; set; }
+    public DateTime? CompletedAt { get; set; }
+    public decimal OverallProgressPercentage { get; set; }
+    public IEnumerable<UserTrainingWorkoutDailyLogDto> DailyLogs { get; set; } = [];
+
+    public static TrainingPlanSubscriberDto FromEntity(Domain.Entities.UserTrainingPlan utp) => new()
+    {
+        UserTrainingPlanId = utp.Id.ToString(),
+        UserId = utp.UserId.ToString(),
+        UserFullName = utp.User is not null ? $"{utp.User.FirstName} {utp.User.Surname}" : string.Empty,
+        Status = utp.UserTrainingPlanStatus,
+        StartedAt = utp.StartedAt,
+        CancelledAt = utp.CancelledAt,
+        CompletedAt = utp.CompletedAt,
+        OverallProgressPercentage = utp.DailyLogs?.Any() == true
+            ? Math.Round(utp.DailyLogs.Average(x => x.ProgressPercentage), 2)
+            : 0m,
+        DailyLogs = utp.DailyLogs?.Select(UserTrainingWorkoutDailyLogDto.FromEntity) ?? []
+    };
+}

--- a/src/backend/DailyFitness.Application/Interfaces/Repositories/ITrainingPlanRepository.cs
+++ b/src/backend/DailyFitness.Application/Interfaces/Repositories/ITrainingPlanRepository.cs
@@ -1,0 +1,13 @@
+using DailyFitness.Domain.Entities;
+using DailyFitness.Domain.ValueObjects;
+
+namespace DailyFitness.Application.Interfaces.Repositories;
+
+public interface ITrainingPlanRepository : IRepository<TrainingPlan>
+{
+    Task<TrainingPlan?> GetWithWorkoutsAndItems(Guid id, CancellationToken ct);
+    Task<IEnumerable<TrainingPlan>> GetAllWithWorkouts(CancellationToken ct);
+    Task<IEnumerable<TrainingPlan>> GetActive(ETrainingObjective? objective, ETrainingLevel? level, CancellationToken ct);
+    Task<IEnumerable<TrainingPlan>> GetByCreator(Guid creatorId, CancellationToken ct);
+    Task<TrainingPlan?> GetWithWorkoutsAndItemsByCreator(Guid id, Guid creatorId, CancellationToken ct);
+}

--- a/src/backend/DailyFitness.Application/Interfaces/Repositories/IUserTrainingPlanRepository.cs
+++ b/src/backend/DailyFitness.Application/Interfaces/Repositories/IUserTrainingPlanRepository.cs
@@ -1,0 +1,13 @@
+using DailyFitness.Domain.Entities;
+using DailyFitness.Domain.ValueObjects;
+
+namespace DailyFitness.Application.Interfaces.Repositories;
+
+public interface IUserTrainingPlanRepository : IRepository<UserTrainingPlan>
+{
+    Task<UserTrainingPlan?> GetActiveByUser(Guid userId, CancellationToken ct);
+    Task<UserTrainingPlan?> GetWithPlanAndProgress(Guid userTrainingPlanId, CancellationToken ct);
+    Task<IEnumerable<UserTrainingPlan>> GetByUser(Guid userId, CancellationToken ct);
+    Task<IEnumerable<UserTrainingPlan>> GetByPlan(Guid trainingPlanId, CancellationToken ct);
+    Task<IEnumerable<UserTrainingPlan>> GetByPlanWithUser(Guid trainingPlanId, CancellationToken ct);
+}

--- a/src/backend/DailyFitness.Application/Interfaces/Repositories/IUserTrainingProgressRepository.cs
+++ b/src/backend/DailyFitness.Application/Interfaces/Repositories/IUserTrainingProgressRepository.cs
@@ -1,0 +1,10 @@
+using DailyFitness.Domain.Entities;
+
+namespace DailyFitness.Application.Interfaces.Repositories;
+
+public interface IUserTrainingProgressRepository : IRepository<UserTrainingProgress>
+{
+    Task<UserTrainingProgress?> GetByPlanItemAndDate(Guid userTrainingPlanId, Guid trainingWorkoutItemId, DateTime progressDate, CancellationToken ct);
+    Task<IEnumerable<UserTrainingProgress>> GetByPlanAndWorkoutAndDate(Guid userTrainingPlanId, Guid trainingWorkoutId, DateTime progressDate, CancellationToken ct);
+    Task<IEnumerable<UserTrainingProgress>> GetByUserTrainingPlan(Guid userTrainingPlanId, CancellationToken ct);
+}

--- a/src/backend/DailyFitness.Application/Interfaces/Repositories/IUserTrainingWorkoutDailyLogRepository.cs
+++ b/src/backend/DailyFitness.Application/Interfaces/Repositories/IUserTrainingWorkoutDailyLogRepository.cs
@@ -1,0 +1,9 @@
+using DailyFitness.Domain.Entities;
+
+namespace DailyFitness.Application.Interfaces.Repositories;
+
+public interface IUserTrainingWorkoutDailyLogRepository : IRepository<UserTrainingWorkoutDailyLog>
+{
+    Task<UserTrainingWorkoutDailyLog?> GetByPlanWorkoutAndDate(Guid userTrainingPlanId, Guid trainingWorkoutId, DateTime progressDate, CancellationToken ct);
+    Task<IEnumerable<UserTrainingWorkoutDailyLog>> GetByUserTrainingPlan(Guid userTrainingPlanId, CancellationToken ct);
+}

--- a/src/backend/DailyFitness.Application/Interfaces/Services/ITrainingPlanService.cs
+++ b/src/backend/DailyFitness.Application/Interfaces/Services/ITrainingPlanService.cs
@@ -1,0 +1,39 @@
+using DailyFitness.Application.Common.Results;
+using DailyFitness.Application.Dtos.TrainingPlan;
+using DailyFitness.Domain.ValueObjects;
+
+namespace DailyFitness.Application.Interfaces.Services;
+
+public interface ITrainingPlanService
+{
+    // ── Admin ─────────────────────────────────────────────────────────────────
+    Task<ResultDto<IEnumerable<TrainingPlanDto>>> GetAllPlans(CancellationToken ct);
+    Task<ResultDto<TrainingPlanDto>> GetPlan(Guid id, CancellationToken ct);
+    Task<ResultDto<TrainingPlanDto>> CreatePlan(CreateTrainingPlanDto model, Guid creatorId, CancellationToken ct);
+    Task<ResultDto<TrainingPlanDto>> UpdatePlan(Guid id, UpdateTrainingPlanDto model, CancellationToken ct);
+    Task<ResultDto<TrainingPlanDto>> ActivatePlan(Guid id, CancellationToken ct);
+    Task<ResultDto<TrainingPlanDto>> DeactivatePlan(Guid id, CancellationToken ct);
+    Task<ResultDto<IEnumerable<TrainingPlanSubscriberDto>>> GetPlanSubscribers(Guid planId, CancellationToken ct);
+    Task<ResultDto<UserTrainingPlanDto>> GetSubscriberProgress(Guid planId, Guid userId, CancellationToken ct);
+
+    // ── Professional ──────────────────────────────────────────────────────────
+    Task<ResultDto<IEnumerable<TrainingPlanDto>>> GetManagedPlans(Guid creatorId, CancellationToken ct);
+    Task<ResultDto<TrainingPlanDto>> GetManagedPlan(Guid id, Guid creatorId, CancellationToken ct);
+    Task<ResultDto<TrainingPlanDto>> CreateManagedPlan(CreateTrainingPlanDto model, Guid creatorId, CancellationToken ct);
+    Task<ResultDto<TrainingPlanDto>> UpdateManagedPlan(Guid id, UpdateTrainingPlanDto model, Guid creatorId, CancellationToken ct);
+    Task<ResultDto<TrainingPlanDto>> ActivateManagedPlan(Guid id, Guid creatorId, CancellationToken ct);
+    Task<ResultDto<TrainingPlanDto>> DeactivateManagedPlan(Guid id, Guid creatorId, CancellationToken ct);
+    Task<ResultDto<IEnumerable<TrainingPlanSubscriberDto>>> GetManagedPlanSubscribers(Guid planId, Guid creatorId, CancellationToken ct);
+    Task<ResultDto<UserTrainingPlanDto>> GetManagedSubscriberProgress(Guid planId, Guid userId, Guid creatorId, CancellationToken ct);
+
+    // ── User ──────────────────────────────────────────────────────────────────
+    Task<ResultDto<IEnumerable<TrainingPlanDto>>> GetAvailablePlans(ETrainingObjective? objective, ETrainingLevel? level, CancellationToken ct);
+    Task<ResultDto<TrainingPlanDto>> GetPlanDetail(Guid id, CancellationToken ct);
+    Task<ResultDto<UserTrainingPlanDto>> SubscribePlan(Guid planId, Guid userId, CancellationToken ct);
+    Task<ResultDto<UserTrainingPlanDto>> CancelSubscription(Guid userId, CancelTrainingPlanDto model, CancellationToken ct);
+    Task<ResultDto<UserTrainingPlanDto>> GetCurrentPlan(Guid userId, CancellationToken ct);
+    Task<ResultDto<UserTrainingPlanDto>> GetCurrentPlanProgress(Guid userId, CancellationToken ct);
+    Task<ResultDto<UserTrainingPlanDto>> MarkItemProgress(Guid userId, Guid workoutId, Guid itemId, MarkTrainingItemProgressDto model, CancellationToken ct);
+    Task<ResultDto<UserTrainingWorkoutDailyLogDto>> FinishWorkoutDay(Guid userId, Guid workoutId, CancellationToken ct);
+    Task<ResultDto<IEnumerable<UserTrainingPlanDto>>> GetHistory(Guid userId, CancellationToken ct);
+}

--- a/src/backend/DailyFitness.Application/Services/TrainingPlanService.cs
+++ b/src/backend/DailyFitness.Application/Services/TrainingPlanService.cs
@@ -1,0 +1,464 @@
+using DailyFitness.Application.Common.Results;
+using DailyFitness.Application.Dtos.TrainingPlan;
+using DailyFitness.Application.Interfaces.Repositories;
+using DailyFitness.Application.Interfaces.Services;
+using DailyFitness.Application.Validators.TrainingPlan;
+using DailyFitness.Domain.Common;
+using DailyFitness.Domain.Entities;
+using DailyFitness.Domain.ValueObjects;
+
+namespace DailyFitness.Application.Services;
+
+public class TrainingPlanService(
+    ITrainingPlanRepository trainingPlanRepository,
+    IUserTrainingPlanRepository userTrainingPlanRepository,
+    IUserTrainingProgressRepository userTrainingProgressRepository,
+    IUserTrainingWorkoutDailyLogRepository userTrainingWorkoutDailyLogRepository)
+    : BaseService, ITrainingPlanService
+{
+    // ── Admin ─────────────────────────────────────────────────────────────────
+
+    public async Task<ResultDto<IEnumerable<TrainingPlanDto>>> GetAllPlans(CancellationToken ct)
+    {
+        var plans = await trainingPlanRepository.GetAllWithWorkouts(ct);
+        return ResultDto<IEnumerable<TrainingPlanDto>>.Ok(plans.Select(TrainingPlanDto.FromEntity));
+    }
+
+    public async Task<ResultDto<TrainingPlanDto>> GetPlan(Guid id, CancellationToken ct)
+    {
+        var plan = await trainingPlanRepository.GetWithWorkoutsAndItems(id, ct);
+        return plan is not null
+            ? ResultDto<TrainingPlanDto>.Ok(TrainingPlanDto.FromEntity(plan))
+            : ResultDto<TrainingPlanDto>.Fail("Plano de treino não encontrado.");
+    }
+
+    public async Task<ResultDto<TrainingPlanDto>> CreatePlan(CreateTrainingPlanDto model, Guid creatorId, CancellationToken ct)
+    {
+        var validation = ExecuteValidation(new CreateTrainingPlanDtoValidator(), model);
+        if (!validation.IsValid)
+            return ResultDto<TrainingPlanDto>.Fail("Falha de validação", validation.Errors.Select(x => x.ErrorMessage).ToList());
+
+        var plan = BuildPlanFromCreate(model, creatorId);
+
+        trainingPlanRepository.Add(plan);
+        await trainingPlanRepository.SaveChanges(ct);
+
+        var created = await trainingPlanRepository.GetWithWorkoutsAndItems(plan.Id, ct);
+        return ResultDto<TrainingPlanDto>.Ok(TrainingPlanDto.FromEntity(created!), "Plano de treino criado com sucesso!");
+    }
+
+    public async Task<ResultDto<TrainingPlanDto>> UpdatePlan(Guid id, UpdateTrainingPlanDto model, CancellationToken ct)
+    {
+        var validation = ExecuteValidation(new UpdateTrainingPlanDtoValidator(), model);
+        if (!validation.IsValid)
+            return ResultDto<TrainingPlanDto>.Fail("Falha de validação", validation.Errors.Select(x => x.ErrorMessage).ToList());
+
+        var plan = await trainingPlanRepository.GetWithWorkoutsAndItems(id, ct);
+        if (plan is null)
+            return ResultDto<TrainingPlanDto>.Fail("Falha de validação", ["Plano de treino não encontrado."]);
+
+        ApplyPlanUpdate(plan, model);
+
+        trainingPlanRepository.Update(plan);
+        await trainingPlanRepository.SaveChanges(ct);
+
+        var updated = await trainingPlanRepository.GetWithWorkoutsAndItems(plan.Id, ct);
+        return ResultDto<TrainingPlanDto>.Ok(TrainingPlanDto.FromEntity(updated!), "Plano de treino atualizado com sucesso!");
+    }
+
+    public async Task<ResultDto<TrainingPlanDto>> ActivatePlan(Guid id, CancellationToken ct)
+    {
+        var plan = await trainingPlanRepository.Get(id, ct);
+        if (plan is null)
+            return ResultDto<TrainingPlanDto>.Fail("Falha de validação", ["Plano de treino não encontrado."]);
+
+        try { plan.SetAsActive(); }
+        catch (InvalidOperationException ex) { return ResultDto<TrainingPlanDto>.Fail("Falha de validação", [ex.Message]); }
+
+        trainingPlanRepository.Update(plan);
+        await trainingPlanRepository.SaveChanges(ct);
+
+        return ResultDto<TrainingPlanDto>.Ok(TrainingPlanDto.FromEntity(plan), "Plano ativado com sucesso!");
+    }
+
+    public async Task<ResultDto<TrainingPlanDto>> DeactivatePlan(Guid id, CancellationToken ct)
+    {
+        var plan = await trainingPlanRepository.Get(id, ct);
+        if (plan is null)
+            return ResultDto<TrainingPlanDto>.Fail("Falha de validação", ["Plano de treino não encontrado."]);
+
+        try { plan.SetAsInactive(); }
+        catch (InvalidOperationException ex) { return ResultDto<TrainingPlanDto>.Fail("Falha de validação", [ex.Message]); }
+
+        trainingPlanRepository.Update(plan);
+        await trainingPlanRepository.SaveChanges(ct);
+
+        return ResultDto<TrainingPlanDto>.Ok(TrainingPlanDto.FromEntity(plan), "Plano inativado com sucesso!");
+    }
+
+    public async Task<ResultDto<IEnumerable<TrainingPlanSubscriberDto>>> GetPlanSubscribers(Guid planId, CancellationToken ct)
+    {
+        var plan = await trainingPlanRepository.Get(planId, ct);
+        if (plan is null)
+            return ResultDto<IEnumerable<TrainingPlanSubscriberDto>>.Fail("Plano de treino não encontrado.");
+
+        var subscribers = await userTrainingPlanRepository.GetByPlanWithUser(planId, ct);
+        return ResultDto<IEnumerable<TrainingPlanSubscriberDto>>.Ok(subscribers.Select(TrainingPlanSubscriberDto.FromEntity));
+    }
+
+    public async Task<ResultDto<UserTrainingPlanDto>> GetSubscriberProgress(Guid planId, Guid userId, CancellationToken ct)
+    {
+        var utp = await userTrainingPlanRepository.GetByUser(userId, ct);
+        var record = utp.FirstOrDefault(x => x.TrainingPlanId == planId);
+        if (record is null)
+            return ResultDto<UserTrainingPlanDto>.Fail("Inscrição não encontrada.");
+
+        var full = await userTrainingPlanRepository.GetWithPlanAndProgress(record.Id, ct);
+        return ResultDto<UserTrainingPlanDto>.Ok(UserTrainingPlanDto.FromEntity(full!));
+    }
+
+    // ── Professional ──────────────────────────────────────────────────────────
+
+    public async Task<ResultDto<IEnumerable<TrainingPlanDto>>> GetManagedPlans(Guid creatorId, CancellationToken ct)
+    {
+        var plans = await trainingPlanRepository.GetByCreator(creatorId, ct);
+        return ResultDto<IEnumerable<TrainingPlanDto>>.Ok(plans.Select(TrainingPlanDto.FromEntity));
+    }
+
+    public async Task<ResultDto<TrainingPlanDto>> GetManagedPlan(Guid id, Guid creatorId, CancellationToken ct)
+    {
+        var plan = await trainingPlanRepository.GetWithWorkoutsAndItemsByCreator(id, creatorId, ct);
+        return plan is not null
+            ? ResultDto<TrainingPlanDto>.Ok(TrainingPlanDto.FromEntity(plan))
+            : ResultDto<TrainingPlanDto>.Fail("Plano não encontrado ou sem permissão de acesso.");
+    }
+
+    public async Task<ResultDto<TrainingPlanDto>> CreateManagedPlan(CreateTrainingPlanDto model, Guid creatorId, CancellationToken ct)
+        => await CreatePlan(model, creatorId, ct);
+
+    public async Task<ResultDto<TrainingPlanDto>> UpdateManagedPlan(Guid id, UpdateTrainingPlanDto model, Guid creatorId, CancellationToken ct)
+    {
+        var validation = ExecuteValidation(new UpdateTrainingPlanDtoValidator(), model);
+        if (!validation.IsValid)
+            return ResultDto<TrainingPlanDto>.Fail("Falha de validação", validation.Errors.Select(x => x.ErrorMessage).ToList());
+
+        var plan = await trainingPlanRepository.GetWithWorkoutsAndItemsByCreator(id, creatorId, ct);
+        if (plan is null)
+            return ResultDto<TrainingPlanDto>.Fail("Falha de validação", ["Plano não encontrado ou sem permissão de acesso."]);
+
+        ApplyPlanUpdate(plan, model);
+
+        trainingPlanRepository.Update(plan);
+        await trainingPlanRepository.SaveChanges(ct);
+
+        var updated = await trainingPlanRepository.GetWithWorkoutsAndItems(plan.Id, ct);
+        return ResultDto<TrainingPlanDto>.Ok(TrainingPlanDto.FromEntity(updated!), "Plano de treino atualizado com sucesso!");
+    }
+
+    public async Task<ResultDto<TrainingPlanDto>> ActivateManagedPlan(Guid id, Guid creatorId, CancellationToken ct)
+    {
+        var plan = await trainingPlanRepository.GetWithWorkoutsAndItemsByCreator(id, creatorId, ct);
+        if (plan is null)
+            return ResultDto<TrainingPlanDto>.Fail("Falha de validação", ["Plano não encontrado ou sem permissão de acesso."]);
+
+        try { plan.SetAsActive(); }
+        catch (InvalidOperationException ex) { return ResultDto<TrainingPlanDto>.Fail("Falha de validação", [ex.Message]); }
+
+        trainingPlanRepository.Update(plan);
+        await trainingPlanRepository.SaveChanges(ct);
+
+        return ResultDto<TrainingPlanDto>.Ok(TrainingPlanDto.FromEntity(plan), "Plano ativado com sucesso!");
+    }
+
+    public async Task<ResultDto<TrainingPlanDto>> DeactivateManagedPlan(Guid id, Guid creatorId, CancellationToken ct)
+    {
+        var plan = await trainingPlanRepository.GetWithWorkoutsAndItemsByCreator(id, creatorId, ct);
+        if (plan is null)
+            return ResultDto<TrainingPlanDto>.Fail("Falha de validação", ["Plano não encontrado ou sem permissão de acesso."]);
+
+        try { plan.SetAsInactive(); }
+        catch (InvalidOperationException ex) { return ResultDto<TrainingPlanDto>.Fail("Falha de validação", [ex.Message]); }
+
+        trainingPlanRepository.Update(plan);
+        await trainingPlanRepository.SaveChanges(ct);
+
+        return ResultDto<TrainingPlanDto>.Ok(TrainingPlanDto.FromEntity(plan), "Plano inativado com sucesso!");
+    }
+
+    public async Task<ResultDto<IEnumerable<TrainingPlanSubscriberDto>>> GetManagedPlanSubscribers(Guid planId, Guid creatorId, CancellationToken ct)
+    {
+        var plan = await trainingPlanRepository.GetWithWorkoutsAndItemsByCreator(planId, creatorId, ct);
+        if (plan is null)
+            return ResultDto<IEnumerable<TrainingPlanSubscriberDto>>.Fail("Plano não encontrado ou sem permissão de acesso.");
+
+        var subscribers = await userTrainingPlanRepository.GetByPlanWithUser(planId, ct);
+        return ResultDto<IEnumerable<TrainingPlanSubscriberDto>>.Ok(subscribers.Select(TrainingPlanSubscriberDto.FromEntity));
+    }
+
+    public async Task<ResultDto<UserTrainingPlanDto>> GetManagedSubscriberProgress(Guid planId, Guid userId, Guid creatorId, CancellationToken ct)
+    {
+        var plan = await trainingPlanRepository.GetWithWorkoutsAndItemsByCreator(planId, creatorId, ct);
+        if (plan is null)
+            return ResultDto<UserTrainingPlanDto>.Fail("Plano não encontrado ou sem permissão de acesso.");
+
+        return await GetSubscriberProgress(planId, userId, ct);
+    }
+
+    // ── User ──────────────────────────────────────────────────────────────────
+
+    public async Task<ResultDto<IEnumerable<TrainingPlanDto>>> GetAvailablePlans(ETrainingObjective? objective, ETrainingLevel? level, CancellationToken ct)
+    {
+        var plans = await trainingPlanRepository.GetActive(objective, level, ct);
+        return ResultDto<IEnumerable<TrainingPlanDto>>.Ok(plans.Select(TrainingPlanDto.FromEntity));
+    }
+
+    public async Task<ResultDto<TrainingPlanDto>> GetPlanDetail(Guid id, CancellationToken ct)
+    {
+        var plan = await trainingPlanRepository.GetWithWorkoutsAndItems(id, ct);
+        if (plan is null)
+            return ResultDto<TrainingPlanDto>.Fail("Plano de treino não encontrado.");
+
+        if (!plan.IsAvailableForSubscription())
+            return ResultDto<TrainingPlanDto>.Fail("Este plano de treino não está disponível.");
+
+        return ResultDto<TrainingPlanDto>.Ok(TrainingPlanDto.FromEntity(plan));
+    }
+
+    public async Task<ResultDto<UserTrainingPlanDto>> SubscribePlan(Guid planId, Guid userId, CancellationToken ct)
+    {
+        var existing = await userTrainingPlanRepository.GetActiveByUser(userId, ct);
+        if (existing is not null)
+            return ResultDto<UserTrainingPlanDto>.Fail("Falha de validação", ["Você já possui um plano de treino ativo. Cancele o atual antes de se associar a outro."]);
+
+        var plan = await trainingPlanRepository.Get(planId, ct);
+        if (plan is null)
+            return ResultDto<UserTrainingPlanDto>.Fail("Falha de validação", ["Plano de treino não encontrado."]);
+
+        if (!plan.IsAvailableForSubscription())
+            return ResultDto<UserTrainingPlanDto>.Fail("Falha de validação", ["Este plano de treino não está disponível para inscrição."]);
+
+        var utp = new UserTrainingPlan(userId, planId);
+        userTrainingPlanRepository.Add(utp);
+        await userTrainingPlanRepository.SaveChanges(ct);
+
+        var created = await userTrainingPlanRepository.GetWithPlanAndProgress(utp.Id, ct);
+        return ResultDto<UserTrainingPlanDto>.Ok(UserTrainingPlanDto.FromEntity(created!), "Inscrição realizada com sucesso!");
+    }
+
+    public async Task<ResultDto<UserTrainingPlanDto>> CancelSubscription(Guid userId, CancelTrainingPlanDto model, CancellationToken ct)
+    {
+        var utp = await userTrainingPlanRepository.GetActiveByUser(userId, ct);
+        if (utp is null)
+            return ResultDto<UserTrainingPlanDto>.Fail("Falha de validação", ["Você não possui um plano de treino ativo."]);
+
+        utp.Cancel(model.Reason);
+        userTrainingPlanRepository.Update(utp);
+        await userTrainingPlanRepository.SaveChanges(ct);
+
+        return ResultDto<UserTrainingPlanDto>.Ok(UserTrainingPlanDto.FromEntity(utp), "Inscrição cancelada com sucesso.");
+    }
+
+    public async Task<ResultDto<UserTrainingPlanDto>> GetCurrentPlan(Guid userId, CancellationToken ct)
+    {
+        var utp = await userTrainingPlanRepository.GetActiveByUser(userId, ct);
+        if (utp is null)
+            return ResultDto<UserTrainingPlanDto>.Fail("Você não possui um plano de treino ativo.");
+
+        var full = await userTrainingPlanRepository.GetWithPlanAndProgress(utp.Id, ct);
+        return ResultDto<UserTrainingPlanDto>.Ok(UserTrainingPlanDto.FromEntity(full!));
+    }
+
+    public async Task<ResultDto<UserTrainingPlanDto>> GetCurrentPlanProgress(Guid userId, CancellationToken ct)
+        => await GetCurrentPlan(userId, ct);
+
+    public async Task<ResultDto<UserTrainingPlanDto>> MarkItemProgress(Guid userId, Guid workoutId, Guid itemId, MarkTrainingItemProgressDto model, CancellationToken ct)
+    {
+        var utp = await userTrainingPlanRepository.GetActiveByUser(userId, ct);
+        if (utp is null)
+            return ResultDto<UserTrainingPlanDto>.Fail("Falha de validação", ["Você não possui um plano de treino ativo."]);
+
+        if (!utp.IsActive())
+            return ResultDto<UserTrainingPlanDto>.Fail("Falha de validação", ["Não é possível registrar progresso em um plano inativo."]);
+
+        // Verifica que o treino e o item pertencem ao plano ativo
+        var workout = utp.TrainingPlan?.Workouts.FirstOrDefault(w => w.Id == workoutId && w.Status == EntityStatus.Active);
+        if (workout is null)
+            return ResultDto<UserTrainingPlanDto>.Fail("Falha de validação", ["Treino não encontrado ou inativo neste plano."]);
+
+        var item = workout.Items.FirstOrDefault(i => i.Id == itemId && i.Status == EntityStatus.Active);
+        if (item is null)
+            return ResultDto<UserTrainingPlanDto>.Fail("Falha de validação", ["Exercício não encontrado ou inativo neste treino."]);
+
+        var today = (model.ProgressDate ?? DateTime.Now).Date;
+
+        // Verifica duplicidade
+        var existing = await userTrainingProgressRepository.GetByPlanItemAndDate(utp.Id, itemId, today, ct);
+        if (existing is not null)
+            return ResultDto<UserTrainingPlanDto>.Fail("Falha de validação", ["Este exercício já foi marcado hoje."]);
+
+        // Registra o progresso
+        var progress = new UserTrainingProgress(utp.Id, workoutId, itemId, today);
+        userTrainingProgressRepository.Add(progress);
+
+        // Recalcula daily log
+        await RecalculateDailyLog(utp.Id, workoutId, workout, today, ct);
+
+        await userTrainingProgressRepository.SaveChanges(ct);
+
+        // Verifica se pode completar o plano
+        await TryCompleteUserTrainingPlan(utp, ct);
+
+        var full = await userTrainingPlanRepository.GetWithPlanAndProgress(utp.Id, ct);
+        return ResultDto<UserTrainingPlanDto>.Ok(UserTrainingPlanDto.FromEntity(full!), "Progresso registrado com sucesso!");
+    }
+
+    public async Task<ResultDto<UserTrainingWorkoutDailyLogDto>> FinishWorkoutDay(Guid userId, Guid workoutId, CancellationToken ct)
+    {
+        var utp = await userTrainingPlanRepository.GetActiveByUser(userId, ct);
+        if (utp is null)
+            return ResultDto<UserTrainingWorkoutDailyLogDto>.Fail("Falha de validação", ["Você não possui um plano de treino ativo."]);
+
+        var workout = utp.TrainingPlan?.Workouts.FirstOrDefault(w => w.Id == workoutId && w.Status == EntityStatus.Active);
+        if (workout is null)
+            return ResultDto<UserTrainingWorkoutDailyLogDto>.Fail("Falha de validação", ["Treino não encontrado neste plano."]);
+
+        var today = DateTime.Now.Date;
+        var log = await userTrainingWorkoutDailyLogRepository.GetByPlanWorkoutAndDate(utp.Id, workoutId, today, ct);
+
+        if (log is null)
+            return ResultDto<UserTrainingWorkoutDailyLogDto>.Fail("Falha de validação", ["Nenhum progresso registrado hoje para este treino."]);
+
+        if (log.IsFinished)
+            return ResultDto<UserTrainingWorkoutDailyLogDto>.Fail("Falha de validação", ["O treino de hoje já foi finalizado."]);
+
+        var activeItemCount = workout.Items.Count(i => i.Status == EntityStatus.Active);
+        var completedToday = await userTrainingProgressRepository.GetByPlanAndWorkoutAndDate(utp.Id, workoutId, today, ct);
+
+        if (completedToday.Count() < activeItemCount)
+            return ResultDto<UserTrainingWorkoutDailyLogDto>.Fail("Falha de validação", ["Ainda há exercícios pendentes para finalizar o treino de hoje."]);
+
+        log.Finish();
+        userTrainingWorkoutDailyLogRepository.Update(log);
+        await userTrainingWorkoutDailyLogRepository.SaveChanges(ct);
+
+        return ResultDto<UserTrainingWorkoutDailyLogDto>.Ok(UserTrainingWorkoutDailyLogDto.FromEntity(log), "Treino do dia finalizado!");
+    }
+
+    public async Task<ResultDto<IEnumerable<UserTrainingPlanDto>>> GetHistory(Guid userId, CancellationToken ct)
+    {
+        var records = await userTrainingPlanRepository.GetByUser(userId, ct);
+        return ResultDto<IEnumerable<UserTrainingPlanDto>>.Ok(records.Select(UserTrainingPlanDto.FromEntity));
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static TrainingPlan BuildPlanFromCreate(CreateTrainingPlanDto model, Guid creatorId)
+    {
+        var plan = new TrainingPlan(
+            model.Name, model.Description, model.Objective,
+            model.Level, model.MinimumDurationDays, model.Instructions, creatorId);
+
+        foreach (var wDto in model.Workouts)
+        {
+            var workout = new TrainingWorkout(plan.Id, wDto.Name, wDto.Order, wDto.Description, wDto.Instructions);
+            foreach (var iDto in wDto.Items)
+                workout.Items.Add(new TrainingWorkoutItem(workout.Id, iDto.Name, iDto.Order, iDto.Description, iDto.Instructions, iDto.Sets, iDto.Repetitions));
+            plan.Workouts.Add(workout);
+        }
+
+        return plan;
+    }
+
+    private static void ApplyPlanUpdate(TrainingPlan plan, UpdateTrainingPlanDto model)
+    {
+        plan.Update(model.Name, model.Description, model.Objective, model.Level, model.MinimumDurationDays, model.Instructions);
+
+        // Atualiza / adiciona workouts e items
+        foreach (var wDto in model.Workouts)
+        {
+            if (wDto.Id.HasValue)
+            {
+                var existing = plan.Workouts.FirstOrDefault(w => w.Id == wDto.Id.Value);
+                if (existing is not null)
+                {
+                    existing.Update(wDto.Name, wDto.Order, wDto.Description, wDto.Instructions);
+
+                    foreach (var iDto in wDto.Items)
+                    {
+                        if (iDto.Id.HasValue)
+                        {
+                            var existingItem = existing.Items.FirstOrDefault(i => i.Id == iDto.Id.Value);
+                            existingItem?.Update(iDto.Name, iDto.Order, iDto.Description, iDto.Instructions, iDto.Sets, iDto.Repetitions);
+                        }
+                        else
+                        {
+                            existing.Items.Add(new TrainingWorkoutItem(existing.Id, iDto.Name, iDto.Order, iDto.Description, iDto.Instructions, iDto.Sets, iDto.Repetitions));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                var workout = new TrainingWorkout(plan.Id, wDto.Name, wDto.Order, wDto.Description, wDto.Instructions);
+                foreach (var iDto in wDto.Items)
+                    workout.Items.Add(new TrainingWorkoutItem(workout.Id, iDto.Name, iDto.Order, iDto.Description, iDto.Instructions, iDto.Sets, iDto.Repetitions));
+                plan.Workouts.Add(workout);
+            }
+        }
+    }
+
+    private async Task RecalculateDailyLog(Guid userTrainingPlanId, Guid workoutId, TrainingWorkout workout, DateTime date, CancellationToken ct)
+    {
+        var activeItemCount = workout.Items.Count(i => i.Status == EntityStatus.Active);
+        if (activeItemCount == 0) return;
+
+        var completedItems = await userTrainingProgressRepository.GetByPlanAndWorkoutAndDate(userTrainingPlanId, workoutId, date, ct);
+        // +1 porque o item atual ainda não foi salvo quando chamamos este método
+        var completedCount = completedItems.Count() + 1;
+        var percentage = Math.Min(100m, Math.Round((decimal)completedCount / activeItemCount * 100, 2));
+
+        var log = await userTrainingWorkoutDailyLogRepository.GetByPlanWorkoutAndDate(userTrainingPlanId, workoutId, date, ct);
+        if (log is null)
+        {
+            log = new UserTrainingWorkoutDailyLog(userTrainingPlanId, workoutId, date, percentage);
+            userTrainingWorkoutDailyLogRepository.Add(log);
+        }
+        else
+        {
+            log.UpdateProgress(percentage);
+            userTrainingWorkoutDailyLogRepository.Update(log);
+        }
+    }
+
+    /// <summary>
+    /// Regra de conclusão automática do plano:
+    /// O plano é concluído quando o usuário atingiu ao menos MinimumDurationDays de treino
+    /// (dias distintos com ao menos um item completado) E todos os treinos de pelo menos
+    /// um ciclo completo (todos os treinos do plano foram realizados pelo menos uma vez).
+    /// </summary>
+    private async Task TryCompleteUserTrainingPlan(UserTrainingPlan utp, CancellationToken ct)
+    {
+        if (!utp.IsActive()) return;
+
+        var allProgresses = await userTrainingProgressRepository.GetByUserTrainingPlan(utp.Id, ct);
+
+        var distinctDays = allProgresses.Select(p => p.ProgressDate.Date).Distinct().Count();
+        if (distinctDays < utp.TrainingPlan?.MinimumDurationDays) return;
+
+        var planWorkoutIds = utp.TrainingPlan?.Workouts
+            .Where(w => w.Status == EntityStatus.Active)
+            .Select(w => w.Id)
+            .ToHashSet() ?? [];
+
+        var completedWorkoutIds = allProgresses
+            .Select(p => p.TrainingWorkoutId)
+            .Distinct()
+            .ToHashSet();
+
+        if (!planWorkoutIds.IsSubsetOf(completedWorkoutIds) || planWorkoutIds.Count == 0) return;
+
+        utp.Complete();
+        userTrainingPlanRepository.Update(utp);
+        await userTrainingPlanRepository.SaveChanges(ct);
+    }
+}

--- a/src/backend/DailyFitness.Application/Validators/TrainingPlan/CreateTrainingPlanDtoValidator.cs
+++ b/src/backend/DailyFitness.Application/Validators/TrainingPlan/CreateTrainingPlanDtoValidator.cs
@@ -1,0 +1,76 @@
+using DailyFitness.Application.Dtos.TrainingPlan;
+using FluentValidation;
+
+namespace DailyFitness.Application.Validators.TrainingPlan;
+
+public class CreateTrainingPlanDtoValidator : AbstractValidator<CreateTrainingPlanDto>
+{
+    public CreateTrainingPlanDtoValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("O nome do plano é obrigatório.")
+            .MinimumLength(3).WithMessage("O nome deve ter no mínimo 3 caracteres.")
+            .MaximumLength(150).WithMessage("O nome deve ter no máximo 150 caracteres.");
+
+        RuleFor(x => x.Description)
+            .NotEmpty().WithMessage("A descrição é obrigatória.")
+            .MaximumLength(4000).WithMessage("A descrição deve ter no máximo 4000 caracteres.");
+
+        RuleFor(x => x.Objective)
+            .IsInEnum().WithMessage("O objetivo do plano é inválido.");
+
+        RuleFor(x => x.Level)
+            .IsInEnum().WithMessage("O nível do plano é inválido.");
+
+        RuleFor(x => x.MinimumDurationDays)
+            .GreaterThan(0).WithMessage("A duração mínima deve ser maior que zero.");
+
+        RuleFor(x => x.Instructions)
+            .MaximumLength(4000).WithMessage("As instruções devem ter no máximo 4000 caracteres.")
+            .When(x => x.Instructions is not null);
+
+        RuleFor(x => x.Workouts)
+            .NotEmpty().WithMessage("O plano deve conter ao menos um treino.");
+
+        RuleForEach(x => x.Workouts).SetValidator(new CreateTrainingWorkoutDtoValidator());
+    }
+}
+
+public class CreateTrainingWorkoutDtoValidator : AbstractValidator<CreateTrainingWorkoutDto>
+{
+    public CreateTrainingWorkoutDtoValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("O nome do treino é obrigatório.")
+            .MaximumLength(150).WithMessage("O nome do treino deve ter no máximo 150 caracteres.");
+
+        RuleFor(x => x.Order)
+            .GreaterThan(0).WithMessage("A ordem do treino deve ser maior que zero.");
+
+        RuleFor(x => x.Items)
+            .NotEmpty().WithMessage("Cada treino deve conter ao menos um exercício.");
+
+        RuleForEach(x => x.Items).SetValidator(new CreateTrainingWorkoutItemDtoValidator());
+    }
+}
+
+public class CreateTrainingWorkoutItemDtoValidator : AbstractValidator<CreateTrainingWorkoutItemDto>
+{
+    public CreateTrainingWorkoutItemDtoValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("O nome do exercício é obrigatório.")
+            .MaximumLength(150).WithMessage("O nome do exercício deve ter no máximo 150 caracteres.");
+
+        RuleFor(x => x.Order)
+            .GreaterThan(0).WithMessage("A ordem do exercício deve ser maior que zero.");
+
+        RuleFor(x => x.Sets)
+            .GreaterThan(0).WithMessage("O número de séries deve ser maior que zero.")
+            .When(x => x.Sets.HasValue);
+
+        RuleFor(x => x.Repetitions)
+            .GreaterThan(0).WithMessage("O número de repetições deve ser maior que zero.")
+            .When(x => x.Repetitions.HasValue);
+    }
+}

--- a/src/backend/DailyFitness.Application/Validators/TrainingPlan/UpdateTrainingPlanDtoValidator.cs
+++ b/src/backend/DailyFitness.Application/Validators/TrainingPlan/UpdateTrainingPlanDtoValidator.cs
@@ -1,0 +1,72 @@
+using DailyFitness.Application.Dtos.TrainingPlan;
+using FluentValidation;
+
+namespace DailyFitness.Application.Validators.TrainingPlan;
+
+public class UpdateTrainingPlanDtoValidator : AbstractValidator<UpdateTrainingPlanDto>
+{
+    public UpdateTrainingPlanDtoValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("O nome do plano é obrigatório.")
+            .MinimumLength(3).WithMessage("O nome deve ter no mínimo 3 caracteres.")
+            .MaximumLength(150).WithMessage("O nome deve ter no máximo 150 caracteres.");
+
+        RuleFor(x => x.Description)
+            .NotEmpty().WithMessage("A descrição é obrigatória.")
+            .MaximumLength(4000).WithMessage("A descrição deve ter no máximo 4000 caracteres.");
+
+        RuleFor(x => x.Objective)
+            .IsInEnum().WithMessage("O objetivo do plano é inválido.");
+
+        RuleFor(x => x.Level)
+            .IsInEnum().WithMessage("O nível do plano é inválido.");
+
+        RuleFor(x => x.MinimumDurationDays)
+            .GreaterThan(0).WithMessage("A duração mínima deve ser maior que zero.");
+
+        RuleFor(x => x.Workouts)
+            .NotEmpty().WithMessage("O plano deve conter ao menos um treino.");
+
+        RuleForEach(x => x.Workouts).SetValidator(new UpsertTrainingWorkoutDtoValidator());
+    }
+}
+
+public class UpsertTrainingWorkoutDtoValidator : AbstractValidator<UpsertTrainingWorkoutDto>
+{
+    public UpsertTrainingWorkoutDtoValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("O nome do treino é obrigatório.")
+            .MaximumLength(150).WithMessage("O nome do treino deve ter no máximo 150 caracteres.");
+
+        RuleFor(x => x.Order)
+            .GreaterThan(0).WithMessage("A ordem do treino deve ser maior que zero.");
+
+        RuleFor(x => x.Items)
+            .NotEmpty().WithMessage("Cada treino deve conter ao menos um exercício.");
+
+        RuleForEach(x => x.Items).SetValidator(new UpsertTrainingWorkoutItemDtoValidator());
+    }
+}
+
+public class UpsertTrainingWorkoutItemDtoValidator : AbstractValidator<UpsertTrainingWorkoutItemDto>
+{
+    public UpsertTrainingWorkoutItemDtoValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("O nome do exercício é obrigatório.")
+            .MaximumLength(150).WithMessage("O nome do exercício deve ter no máximo 150 caracteres.");
+
+        RuleFor(x => x.Order)
+            .GreaterThan(0).WithMessage("A ordem do exercício deve ser maior que zero.");
+
+        RuleFor(x => x.Sets)
+            .GreaterThan(0).WithMessage("O número de séries deve ser maior que zero.")
+            .When(x => x.Sets.HasValue);
+
+        RuleFor(x => x.Repetitions)
+            .GreaterThan(0).WithMessage("O número de repetições deve ser maior que zero.")
+            .When(x => x.Repetitions.HasValue);
+    }
+}

--- a/src/backend/DailyFitness.Domain/Entities/TrainingPlan.cs
+++ b/src/backend/DailyFitness.Domain/Entities/TrainingPlan.cs
@@ -1,0 +1,67 @@
+using DailyFitness.Domain.Common;
+using DailyFitness.Domain.ValueObjects;
+
+namespace DailyFitness.Domain.Entities;
+
+public class TrainingPlan : Entity
+{
+    public string Name { get; private set; }
+    public string Description { get; private set; }
+    public ETrainingObjective Objective { get; private set; }
+    public ETrainingLevel Level { get; private set; }
+    public string? Instructions { get; private set; }
+    public int MinimumDurationDays { get; private set; }
+    public Guid? CreatedByUserId { get; private set; }
+
+    public User? CreatedByUser { get; set; }
+    public ICollection<TrainingWorkout> Workouts { get; init; }
+    public ICollection<UserTrainingPlan> UserTrainingPlans { get; init; }
+
+    public TrainingPlan()
+    {
+        Name = string.Empty;
+        Description = string.Empty;
+        Workouts = new List<TrainingWorkout>();
+        UserTrainingPlans = new List<UserTrainingPlan>();
+    }
+
+    public TrainingPlan(
+        string name,
+        string description,
+        ETrainingObjective objective,
+        ETrainingLevel level,
+        int minimumDurationDays,
+        string? instructions = null,
+        Guid? createdByUserId = null) : base()
+    {
+        Name = name;
+        Description = description;
+        Objective = objective;
+        Level = level;
+        MinimumDurationDays = minimumDurationDays;
+        Instructions = instructions;
+        CreatedByUserId = createdByUserId;
+        Workouts = new List<TrainingWorkout>();
+        UserTrainingPlans = new List<UserTrainingPlan>();
+    }
+
+    public void Update(
+        string name,
+        string description,
+        ETrainingObjective objective,
+        ETrainingLevel level,
+        int minimumDurationDays,
+        string? instructions)
+    {
+        Name = name;
+        Description = description;
+        Objective = objective;
+        Level = level;
+        MinimumDurationDays = minimumDurationDays;
+        Instructions = instructions;
+        UpdatedAt = DateTime.Now;
+    }
+
+    public bool IsAvailableForSubscription() =>
+        Status == EntityStatus.Active;
+}

--- a/src/backend/DailyFitness.Domain/Entities/TrainingWorkout.cs
+++ b/src/backend/DailyFitness.Domain/Entities/TrainingWorkout.cs
@@ -1,0 +1,45 @@
+using DailyFitness.Domain.Common;
+
+namespace DailyFitness.Domain.Entities;
+
+public class TrainingWorkout : Entity
+{
+    public Guid TrainingPlanId { get; private set; }
+    public string Name { get; private set; }
+    public string? Description { get; private set; }
+    public string? Instructions { get; private set; }
+    public int Order { get; private set; }
+
+    public TrainingPlan? TrainingPlan { get; set; }
+    public ICollection<TrainingWorkoutItem> Items { get; init; }
+
+    public TrainingWorkout()
+    {
+        Name = string.Empty;
+        Items = new List<TrainingWorkoutItem>();
+    }
+
+    public TrainingWorkout(
+        Guid trainingPlanId,
+        string name,
+        int order,
+        string? description = null,
+        string? instructions = null) : base()
+    {
+        TrainingPlanId = trainingPlanId;
+        Name = name;
+        Order = order;
+        Description = description;
+        Instructions = instructions;
+        Items = new List<TrainingWorkoutItem>();
+    }
+
+    public void Update(string name, int order, string? description, string? instructions)
+    {
+        Name = name;
+        Order = order;
+        Description = description;
+        Instructions = instructions;
+        UpdatedAt = DateTime.Now;
+    }
+}

--- a/src/backend/DailyFitness.Domain/Entities/TrainingWorkoutItem.cs
+++ b/src/backend/DailyFitness.Domain/Entities/TrainingWorkoutItem.cs
@@ -1,0 +1,50 @@
+using DailyFitness.Domain.Common;
+
+namespace DailyFitness.Domain.Entities;
+
+public class TrainingWorkoutItem : Entity
+{
+    public Guid TrainingWorkoutId { get; private set; }
+    public string Name { get; private set; }
+    public string? Description { get; private set; }
+    public string? Instructions { get; private set; }
+    public int? Sets { get; private set; }
+    public int? Repetitions { get; private set; }
+    public int Order { get; private set; }
+
+    public TrainingWorkout? TrainingWorkout { get; set; }
+
+    public TrainingWorkoutItem()
+    {
+        Name = string.Empty;
+    }
+
+    public TrainingWorkoutItem(
+        Guid trainingWorkoutId,
+        string name,
+        int order,
+        string? description = null,
+        string? instructions = null,
+        int? sets = null,
+        int? repetitions = null) : base()
+    {
+        TrainingWorkoutId = trainingWorkoutId;
+        Name = name;
+        Order = order;
+        Description = description;
+        Instructions = instructions;
+        Sets = sets;
+        Repetitions = repetitions;
+    }
+
+    public void Update(string name, int order, string? description, string? instructions, int? sets, int? repetitions)
+    {
+        Name = name;
+        Order = order;
+        Description = description;
+        Instructions = instructions;
+        Sets = sets;
+        Repetitions = repetitions;
+        UpdatedAt = DateTime.Now;
+    }
+}

--- a/src/backend/DailyFitness.Domain/Entities/UserTrainingPlan.cs
+++ b/src/backend/DailyFitness.Domain/Entities/UserTrainingPlan.cs
@@ -1,0 +1,53 @@
+using DailyFitness.Domain.Common;
+using DailyFitness.Domain.ValueObjects;
+
+namespace DailyFitness.Domain.Entities;
+
+public class UserTrainingPlan : Entity
+{
+    public Guid UserId { get; private set; }
+    public Guid TrainingPlanId { get; private set; }
+    public EUserTrainingPlanStatus UserTrainingPlanStatus { get; private set; }
+    public DateTime StartedAt { get; private set; }
+    public DateTime? CancelledAt { get; private set; }
+    public DateTime? CompletedAt { get; private set; }
+    public string? CancellationReason { get; private set; }
+
+    public User? User { get; set; }
+    public TrainingPlan? TrainingPlan { get; set; }
+    public ICollection<UserTrainingProgress> Progresses { get; init; }
+    public ICollection<UserTrainingWorkoutDailyLog> DailyLogs { get; init; }
+
+    public UserTrainingPlan()
+    {
+        Progresses = new List<UserTrainingProgress>();
+        DailyLogs = new List<UserTrainingWorkoutDailyLog>();
+    }
+
+    public UserTrainingPlan(Guid userId, Guid trainingPlanId) : base()
+    {
+        UserId = userId;
+        TrainingPlanId = trainingPlanId;
+        UserTrainingPlanStatus = EUserTrainingPlanStatus.Active;
+        StartedAt = DateTime.Now;
+        Progresses = new List<UserTrainingProgress>();
+        DailyLogs = new List<UserTrainingWorkoutDailyLog>();
+    }
+
+    public void Cancel(string? reason = null)
+    {
+        UserTrainingPlanStatus = EUserTrainingPlanStatus.Cancelled;
+        CancelledAt = DateTime.Now;
+        CancellationReason = reason;
+        UpdatedAt = DateTime.Now;
+    }
+
+    public void Complete()
+    {
+        UserTrainingPlanStatus = EUserTrainingPlanStatus.Completed;
+        CompletedAt = DateTime.Now;
+        UpdatedAt = DateTime.Now;
+    }
+
+    public bool IsActive() => UserTrainingPlanStatus == EUserTrainingPlanStatus.Active;
+}

--- a/src/backend/DailyFitness.Domain/Entities/UserTrainingProgress.cs
+++ b/src/backend/DailyFitness.Domain/Entities/UserTrainingProgress.cs
@@ -1,0 +1,33 @@
+using DailyFitness.Domain.Common;
+
+namespace DailyFitness.Domain.Entities;
+
+public class UserTrainingProgress : Entity
+{
+    public Guid UserTrainingPlanId { get; private set; }
+    public Guid TrainingWorkoutId { get; private set; }
+    public Guid TrainingWorkoutItemId { get; private set; }
+    public DateTime ProgressDate { get; private set; }
+    public DateTime CompletedAt { get; private set; }
+
+    public UserTrainingPlan? UserTrainingPlan { get; set; }
+    public TrainingWorkout? TrainingWorkout { get; set; }
+    public TrainingWorkoutItem? TrainingWorkoutItem { get; set; }
+
+    public UserTrainingProgress()
+    {
+    }
+
+    public UserTrainingProgress(
+        Guid userTrainingPlanId,
+        Guid trainingWorkoutId,
+        Guid trainingWorkoutItemId,
+        DateTime progressDate) : base()
+    {
+        UserTrainingPlanId = userTrainingPlanId;
+        TrainingWorkoutId = trainingWorkoutId;
+        TrainingWorkoutItemId = trainingWorkoutItemId;
+        ProgressDate = progressDate;
+        CompletedAt = DateTime.Now;
+    }
+}

--- a/src/backend/DailyFitness.Domain/Entities/UserTrainingWorkoutDailyLog.cs
+++ b/src/backend/DailyFitness.Domain/Entities/UserTrainingWorkoutDailyLog.cs
@@ -1,0 +1,46 @@
+using DailyFitness.Domain.Common;
+
+namespace DailyFitness.Domain.Entities;
+
+public class UserTrainingWorkoutDailyLog : Entity
+{
+    public Guid UserTrainingPlanId { get; private set; }
+    public Guid TrainingWorkoutId { get; private set; }
+    public DateTime ProgressDate { get; private set; }
+    public decimal ProgressPercentage { get; private set; }
+    public bool IsFinished { get; private set; }
+    public DateTime? FinishedAt { get; private set; }
+
+    public UserTrainingPlan? UserTrainingPlan { get; set; }
+    public TrainingWorkout? TrainingWorkout { get; set; }
+
+    public UserTrainingWorkoutDailyLog()
+    {
+    }
+
+    public UserTrainingWorkoutDailyLog(
+        Guid userTrainingPlanId,
+        Guid trainingWorkoutId,
+        DateTime progressDate,
+        decimal progressPercentage) : base()
+    {
+        UserTrainingPlanId = userTrainingPlanId;
+        TrainingWorkoutId = trainingWorkoutId;
+        ProgressDate = progressDate;
+        ProgressPercentage = progressPercentage;
+    }
+
+    public void UpdateProgress(decimal progressPercentage)
+    {
+        ProgressPercentage = progressPercentage;
+        UpdatedAt = DateTime.Now;
+    }
+
+    public void Finish()
+    {
+        IsFinished = true;
+        FinishedAt = DateTime.Now;
+        ProgressPercentage = 100m;
+        UpdatedAt = DateTime.Now;
+    }
+}

--- a/src/backend/DailyFitness.Domain/ValueObjects/ETrainingLevel.cs
+++ b/src/backend/DailyFitness.Domain/ValueObjects/ETrainingLevel.cs
@@ -1,0 +1,8 @@
+namespace DailyFitness.Domain.ValueObjects;
+
+public enum ETrainingLevel
+{
+    Beginner = 1,
+    Intermediate = 2,
+    Advanced = 3
+}

--- a/src/backend/DailyFitness.Domain/ValueObjects/ETrainingObjective.cs
+++ b/src/backend/DailyFitness.Domain/ValueObjects/ETrainingObjective.cs
@@ -1,0 +1,11 @@
+namespace DailyFitness.Domain.ValueObjects;
+
+public enum ETrainingObjective
+{
+    WeightLoss = 1,
+    MuscleGain = 2,
+    Endurance = 3,
+    Flexibility = 4,
+    GeneralFitness = 5,
+    Performance = 6
+}

--- a/src/backend/DailyFitness.Domain/ValueObjects/EUserTrainingPlanStatus.cs
+++ b/src/backend/DailyFitness.Domain/ValueObjects/EUserTrainingPlanStatus.cs
@@ -1,0 +1,8 @@
+namespace DailyFitness.Domain.ValueObjects;
+
+public enum EUserTrainingPlanStatus
+{
+    Active = 1,
+    Cancelled = 2,
+    Completed = 3
+}

--- a/src/backend/DailyFitness.Infrastructure/DependencyInjection.cs
+++ b/src/backend/DailyFitness.Infrastructure/DependencyInjection.cs
@@ -50,6 +50,10 @@ public static class DependencyInjection
             services.AddScoped<IChallengeRepository, ChallengeRepository>();
             services.AddScoped<IUserChallengeRepository, UserChallengeRepository>();
             services.AddScoped<IUserChallengeProgressRepository, UserChallengeProgressRepository>();
+            services.AddScoped<ITrainingPlanRepository, TrainingPlanRepository>();
+            services.AddScoped<IUserTrainingPlanRepository, UserTrainingPlanRepository>();
+            services.AddScoped<IUserTrainingProgressRepository, UserTrainingProgressRepository>();
+            services.AddScoped<IUserTrainingWorkoutDailyLogRepository, UserTrainingWorkoutDailyLogRepository>();
         }
     }
 }

--- a/src/backend/DailyFitness.Infrastructure/Migrations/20260524000000_AddingTrainingPlans.cs
+++ b/src/backend/DailyFitness.Infrastructure/Migrations/20260524000000_AddingTrainingPlans.cs
@@ -1,0 +1,248 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DailyFitness.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddingTrainingPlans : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TrainingPlans",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "char(36)", nullable: false),
+                    Name = table.Column<string>(type: "varchar(150)", maxLength: 150, nullable: false),
+                    Description = table.Column<string>(type: "varchar(4000)", maxLength: 4000, nullable: false),
+                    Objective = table.Column<int>(type: "int", nullable: false),
+                    Level = table.Column<int>(type: "int", nullable: false),
+                    Instructions = table.Column<string>(type: "varchar(4000)", maxLength: 4000, nullable: true),
+                    MinimumDurationDays = table.Column<int>(type: "int", nullable: false),
+                    CreatedByUserId = table.Column<Guid>(type: "char(36)", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TrainingPlans", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TrainingPlans_Users_CreatedByUserId",
+                        column: x => x.CreatedByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                })
+                .Annotation("MySQL:Charset", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "TrainingWorkouts",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "char(36)", nullable: false),
+                    TrainingPlanId = table.Column<Guid>(type: "char(36)", nullable: false),
+                    Name = table.Column<string>(type: "varchar(150)", maxLength: 150, nullable: false),
+                    Description = table.Column<string>(type: "varchar(2000)", maxLength: 2000, nullable: true),
+                    Instructions = table.Column<string>(type: "varchar(4000)", maxLength: 4000, nullable: true),
+                    Order = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TrainingWorkouts", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TrainingWorkouts_TrainingPlans_TrainingPlanId",
+                        column: x => x.TrainingPlanId,
+                        principalTable: "TrainingPlans",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySQL:Charset", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "TrainingWorkoutItems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "char(36)", nullable: false),
+                    TrainingWorkoutId = table.Column<Guid>(type: "char(36)", nullable: false),
+                    Name = table.Column<string>(type: "varchar(150)", maxLength: 150, nullable: false),
+                    Description = table.Column<string>(type: "varchar(2000)", maxLength: 2000, nullable: true),
+                    Instructions = table.Column<string>(type: "varchar(4000)", maxLength: 4000, nullable: true),
+                    Sets = table.Column<int>(type: "int", nullable: true),
+                    Repetitions = table.Column<int>(type: "int", nullable: true),
+                    Order = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TrainingWorkoutItems", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TrainingWorkoutItems_TrainingWorkouts_TrainingWorkoutId",
+                        column: x => x.TrainingWorkoutId,
+                        principalTable: "TrainingWorkouts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySQL:Charset", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "UserTrainingPlans",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "char(36)", nullable: false),
+                    UserId = table.Column<Guid>(type: "char(36)", nullable: false),
+                    TrainingPlanId = table.Column<Guid>(type: "char(36)", nullable: false),
+                    UserTrainingPlanStatus = table.Column<int>(type: "int", nullable: false),
+                    StartedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    CancelledAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    CompletedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    CancellationReason = table.Column<string>(type: "varchar(1000)", maxLength: 1000, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserTrainingPlans", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserTrainingPlans_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_UserTrainingPlans_TrainingPlans_TrainingPlanId",
+                        column: x => x.TrainingPlanId,
+                        principalTable: "TrainingPlans",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySQL:Charset", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "UserTrainingProgresses",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "char(36)", nullable: false),
+                    UserTrainingPlanId = table.Column<Guid>(type: "char(36)", nullable: false),
+                    TrainingWorkoutId = table.Column<Guid>(type: "char(36)", nullable: false),
+                    TrainingWorkoutItemId = table.Column<Guid>(type: "char(36)", nullable: false),
+                    ProgressDate = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    CompletedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserTrainingProgresses", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserTrainingProgresses_UserTrainingPlans_UserTrainingPlanId",
+                        column: x => x.UserTrainingPlanId,
+                        principalTable: "UserTrainingPlans",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_UserTrainingProgresses_TrainingWorkouts_TrainingWorkoutId",
+                        column: x => x.TrainingWorkoutId,
+                        principalTable: "TrainingWorkouts",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_UserTrainingProgresses_TrainingWorkoutItems_TrainingWorkoutItemId",
+                        column: x => x.TrainingWorkoutItemId,
+                        principalTable: "TrainingWorkoutItems",
+                        principalColumn: "Id");
+                })
+                .Annotation("MySQL:Charset", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "UserTrainingWorkoutDailyLogs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "char(36)", nullable: false),
+                    UserTrainingPlanId = table.Column<Guid>(type: "char(36)", nullable: false),
+                    TrainingWorkoutId = table.Column<Guid>(type: "char(36)", nullable: false),
+                    ProgressDate = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    ProgressPercentage = table.Column<decimal>(type: "decimal(5,2)", precision: 5, scale: 2, nullable: false),
+                    IsFinished = table.Column<bool>(type: "tinyint(1)", nullable: false),
+                    FinishedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserTrainingWorkoutDailyLogs", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserTrainingWorkoutDailyLogs_UserTrainingPlans_UserTrainingPlanId",
+                        column: x => x.UserTrainingPlanId,
+                        principalTable: "UserTrainingPlans",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_UserTrainingWorkoutDailyLogs_TrainingWorkouts_TrainingWorkoutId",
+                        column: x => x.TrainingWorkoutId,
+                        principalTable: "TrainingWorkouts",
+                        principalColumn: "Id");
+                })
+                .Annotation("MySQL:Charset", "utf8mb4");
+
+            // Índices TrainingPlans
+            migrationBuilder.CreateIndex(name: "IX_TrainingPlans_Objective", table: "TrainingPlans", column: "Objective");
+            migrationBuilder.CreateIndex(name: "IX_TrainingPlans_Level", table: "TrainingPlans", column: "Level");
+            migrationBuilder.CreateIndex(name: "IX_TrainingPlans_Status", table: "TrainingPlans", column: "Status");
+            migrationBuilder.CreateIndex(name: "IX_TrainingPlans_CreatedByUserId", table: "TrainingPlans", column: "CreatedByUserId");
+
+            // Índices TrainingWorkouts
+            migrationBuilder.CreateIndex(name: "IX_TrainingWorkouts_TrainingPlanId", table: "TrainingWorkouts", column: "TrainingPlanId");
+            migrationBuilder.CreateIndex(name: "IX_TrainingWorkouts_TrainingPlanId_Order", table: "TrainingWorkouts", columns: new[] { "TrainingPlanId", "Order" });
+
+            // Índices TrainingWorkoutItems
+            migrationBuilder.CreateIndex(name: "IX_TrainingWorkoutItems_TrainingWorkoutId", table: "TrainingWorkoutItems", column: "TrainingWorkoutId");
+            migrationBuilder.CreateIndex(name: "IX_TrainingWorkoutItems_TrainingWorkoutId_Order", table: "TrainingWorkoutItems", columns: new[] { "TrainingWorkoutId", "Order" });
+
+            // Índices UserTrainingPlans
+            migrationBuilder.CreateIndex(name: "IX_UserTrainingPlans_UserId", table: "UserTrainingPlans", column: "UserId");
+            migrationBuilder.CreateIndex(name: "IX_UserTrainingPlans_TrainingPlanId", table: "UserTrainingPlans", column: "TrainingPlanId");
+            migrationBuilder.CreateIndex(name: "IX_UserTrainingPlans_UserTrainingPlanStatus", table: "UserTrainingPlans", column: "UserTrainingPlanStatus");
+            migrationBuilder.CreateIndex(name: "IX_UserTrainingPlans_UserId_UserTrainingPlanStatus", table: "UserTrainingPlans", columns: new[] { "UserId", "UserTrainingPlanStatus" });
+
+            // Índices UserTrainingProgresses
+            migrationBuilder.CreateIndex(name: "IX_UserTrainingProgresses_UserTrainingPlanId", table: "UserTrainingProgresses", column: "UserTrainingPlanId");
+            migrationBuilder.CreateIndex(name: "IX_UserTrainingProgresses_TrainingWorkoutId", table: "UserTrainingProgresses", column: "TrainingWorkoutId");
+            // Unique: impede duplicidade de item no mesmo dia para o mesmo plano
+            migrationBuilder.CreateIndex(
+                name: "IX_UserTrainingProgresses_PlanItemDate",
+                table: "UserTrainingProgresses",
+                columns: new[] { "UserTrainingPlanId", "TrainingWorkoutItemId", "ProgressDate" },
+                unique: true);
+
+            // Índices UserTrainingWorkoutDailyLogs
+            migrationBuilder.CreateIndex(name: "IX_UserTrainingWorkoutDailyLogs_UserTrainingPlanId", table: "UserTrainingWorkoutDailyLogs", column: "UserTrainingPlanId");
+            migrationBuilder.CreateIndex(
+                name: "IX_UserTrainingWorkoutDailyLogs_PlanWorkoutDate",
+                table: "UserTrainingWorkoutDailyLogs",
+                columns: new[] { "UserTrainingPlanId", "TrainingWorkoutId", "ProgressDate" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "UserTrainingWorkoutDailyLogs");
+            migrationBuilder.DropTable(name: "UserTrainingProgresses");
+            migrationBuilder.DropTable(name: "UserTrainingPlans");
+            migrationBuilder.DropTable(name: "TrainingWorkoutItems");
+            migrationBuilder.DropTable(name: "TrainingWorkouts");
+            migrationBuilder.DropTable(name: "TrainingPlans");
+        }
+    }
+}

--- a/src/backend/DailyFitness.Infrastructure/Migrations/20260524155001_AddingTrainingPlans2.Designer.cs
+++ b/src/backend/DailyFitness.Infrastructure/Migrations/20260524155001_AddingTrainingPlans2.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DailyFitness.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DailyFitness.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260524155001_AddingTrainingPlans2")]
+    partial class AddingTrainingPlans2
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/DailyFitness.Infrastructure/Migrations/20260524155001_AddingTrainingPlans2.cs
+++ b/src/backend/DailyFitness.Infrastructure/Migrations/20260524155001_AddingTrainingPlans2.cs
@@ -1,0 +1,318 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DailyFitness.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddingTrainingPlans2 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TrainingPlans",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "char(36)", nullable: false),
+                    Name = table.Column<string>(type: "varchar(150)", maxLength: 150, nullable: false),
+                    Description = table.Column<string>(type: "varchar(4000)", maxLength: 4000, nullable: false),
+                    Objective = table.Column<int>(type: "int", nullable: false),
+                    Level = table.Column<int>(type: "int", nullable: false),
+                    Instructions = table.Column<string>(type: "varchar(4000)", maxLength: 4000, nullable: true),
+                    MinimumDurationDays = table.Column<int>(type: "int", nullable: false),
+                    CreatedByUserId = table.Column<Guid>(type: "char(36)", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TrainingPlans", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TrainingPlans_Users_CreatedByUserId",
+                        column: x => x.CreatedByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                })
+                .Annotation("MySQL:Charset", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "TrainingWorkouts",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "char(36)", nullable: false),
+                    TrainingPlanId = table.Column<Guid>(type: "char(36)", nullable: false),
+                    Name = table.Column<string>(type: "varchar(150)", maxLength: 150, nullable: false),
+                    Description = table.Column<string>(type: "varchar(2000)", maxLength: 2000, nullable: true),
+                    Instructions = table.Column<string>(type: "varchar(4000)", maxLength: 4000, nullable: true),
+                    Order = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TrainingWorkouts", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TrainingWorkouts_TrainingPlans_TrainingPlanId",
+                        column: x => x.TrainingPlanId,
+                        principalTable: "TrainingPlans",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySQL:Charset", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "UserTrainingPlans",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "char(36)", nullable: false),
+                    UserId = table.Column<Guid>(type: "char(36)", nullable: false),
+                    TrainingPlanId = table.Column<Guid>(type: "char(36)", nullable: false),
+                    UserTrainingPlanStatus = table.Column<int>(type: "int", nullable: false),
+                    StartedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    CancelledAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    CompletedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    CancellationReason = table.Column<string>(type: "varchar(1000)", maxLength: 1000, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserTrainingPlans", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserTrainingPlans_TrainingPlans_TrainingPlanId",
+                        column: x => x.TrainingPlanId,
+                        principalTable: "TrainingPlans",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_UserTrainingPlans_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySQL:Charset", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "TrainingWorkoutItems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "char(36)", nullable: false),
+                    TrainingWorkoutId = table.Column<Guid>(type: "char(36)", nullable: false),
+                    Name = table.Column<string>(type: "varchar(150)", maxLength: 150, nullable: false),
+                    Description = table.Column<string>(type: "varchar(2000)", maxLength: 2000, nullable: true),
+                    Instructions = table.Column<string>(type: "varchar(4000)", maxLength: 4000, nullable: true),
+                    Sets = table.Column<int>(type: "int", nullable: true),
+                    Repetitions = table.Column<int>(type: "int", nullable: true),
+                    Order = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TrainingWorkoutItems", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TrainingWorkoutItems_TrainingWorkouts_TrainingWorkoutId",
+                        column: x => x.TrainingWorkoutId,
+                        principalTable: "TrainingWorkouts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySQL:Charset", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "UserTrainingWorkoutDailyLogs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "char(36)", nullable: false),
+                    UserTrainingPlanId = table.Column<Guid>(type: "char(36)", nullable: false),
+                    TrainingWorkoutId = table.Column<Guid>(type: "char(36)", nullable: false),
+                    ProgressDate = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    ProgressPercentage = table.Column<decimal>(type: "decimal(5,2)", precision: 5, scale: 2, nullable: false),
+                    IsFinished = table.Column<bool>(type: "tinyint(1)", nullable: false),
+                    FinishedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserTrainingWorkoutDailyLogs", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserTrainingWorkoutDailyLogs_TrainingWorkouts_TrainingWorkou~",
+                        column: x => x.TrainingWorkoutId,
+                        principalTable: "TrainingWorkouts",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_UserTrainingWorkoutDailyLogs_UserTrainingPlans_UserTrainingP~",
+                        column: x => x.UserTrainingPlanId,
+                        principalTable: "UserTrainingPlans",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySQL:Charset", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "UserTrainingProgresses",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "char(36)", nullable: false),
+                    UserTrainingPlanId = table.Column<Guid>(type: "char(36)", nullable: false),
+                    TrainingWorkoutId = table.Column<Guid>(type: "char(36)", nullable: false),
+                    TrainingWorkoutItemId = table.Column<Guid>(type: "char(36)", nullable: false),
+                    ProgressDate = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    CompletedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserTrainingProgresses", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserTrainingProgresses_TrainingWorkoutItems_TrainingWorkoutI~",
+                        column: x => x.TrainingWorkoutItemId,
+                        principalTable: "TrainingWorkoutItems",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_UserTrainingProgresses_TrainingWorkouts_TrainingWorkoutId",
+                        column: x => x.TrainingWorkoutId,
+                        principalTable: "TrainingWorkouts",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_UserTrainingProgresses_UserTrainingPlans_UserTrainingPlanId",
+                        column: x => x.UserTrainingPlanId,
+                        principalTable: "UserTrainingPlans",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySQL:Charset", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TrainingPlans_CreatedByUserId",
+                table: "TrainingPlans",
+                column: "CreatedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TrainingPlans_Level",
+                table: "TrainingPlans",
+                column: "Level");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TrainingPlans_Objective",
+                table: "TrainingPlans",
+                column: "Objective");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TrainingPlans_Status",
+                table: "TrainingPlans",
+                column: "Status");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TrainingWorkoutItems_TrainingWorkoutId",
+                table: "TrainingWorkoutItems",
+                column: "TrainingWorkoutId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TrainingWorkoutItems_TrainingWorkoutId_Order",
+                table: "TrainingWorkoutItems",
+                columns: new[] { "TrainingWorkoutId", "Order" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TrainingWorkouts_TrainingPlanId",
+                table: "TrainingWorkouts",
+                column: "TrainingPlanId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TrainingWorkouts_TrainingPlanId_Order",
+                table: "TrainingWorkouts",
+                columns: new[] { "TrainingPlanId", "Order" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserTrainingPlans_TrainingPlanId",
+                table: "UserTrainingPlans",
+                column: "TrainingPlanId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserTrainingPlans_UserId",
+                table: "UserTrainingPlans",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserTrainingPlans_UserId_UserTrainingPlanStatus",
+                table: "UserTrainingPlans",
+                columns: new[] { "UserId", "UserTrainingPlanStatus" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserTrainingPlans_UserTrainingPlanStatus",
+                table: "UserTrainingPlans",
+                column: "UserTrainingPlanStatus");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserTrainingProgresses_TrainingWorkoutId",
+                table: "UserTrainingProgresses",
+                column: "TrainingWorkoutId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserTrainingProgresses_TrainingWorkoutItemId",
+                table: "UserTrainingProgresses",
+                column: "TrainingWorkoutItemId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserTrainingProgresses_UserTrainingPlanId",
+                table: "UserTrainingProgresses",
+                column: "UserTrainingPlanId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserTrainingProgresses_UserTrainingPlanId_TrainingWorkoutIte~",
+                table: "UserTrainingProgresses",
+                columns: new[] { "UserTrainingPlanId", "TrainingWorkoutItemId", "ProgressDate" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserTrainingWorkoutDailyLogs_TrainingWorkoutId",
+                table: "UserTrainingWorkoutDailyLogs",
+                column: "TrainingWorkoutId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserTrainingWorkoutDailyLogs_UserTrainingPlanId",
+                table: "UserTrainingWorkoutDailyLogs",
+                column: "UserTrainingPlanId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserTrainingWorkoutDailyLogs_UserTrainingPlanId_TrainingWork~",
+                table: "UserTrainingWorkoutDailyLogs",
+                columns: new[] { "UserTrainingPlanId", "TrainingWorkoutId", "ProgressDate" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserTrainingProgresses");
+
+            migrationBuilder.DropTable(
+                name: "UserTrainingWorkoutDailyLogs");
+
+            migrationBuilder.DropTable(
+                name: "TrainingWorkoutItems");
+
+            migrationBuilder.DropTable(
+                name: "UserTrainingPlans");
+
+            migrationBuilder.DropTable(
+                name: "TrainingWorkouts");
+
+            migrationBuilder.DropTable(
+                name: "TrainingPlans");
+        }
+    }
+}

--- a/src/backend/DailyFitness.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/backend/DailyFitness.Infrastructure/Persistence/AppDbContext.cs
@@ -13,6 +13,12 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<Challenge> Challenges => Set<Challenge>();
     public DbSet<UserChallenge> UserChallenges => Set<UserChallenge>();
     public DbSet<UserChallengeProgress> UserChallengeProgresses => Set<UserChallengeProgress>();
+    public DbSet<TrainingPlan> TrainingPlans => Set<TrainingPlan>();
+    public DbSet<TrainingWorkout> TrainingWorkouts => Set<TrainingWorkout>();
+    public DbSet<TrainingWorkoutItem> TrainingWorkoutItems => Set<TrainingWorkoutItem>();
+    public DbSet<UserTrainingPlan> UserTrainingPlans => Set<UserTrainingPlan>();
+    public DbSet<UserTrainingProgress> UserTrainingProgresses => Set<UserTrainingProgress>();
+    public DbSet<UserTrainingWorkoutDailyLog> UserTrainingWorkoutDailyLogs => Set<UserTrainingWorkoutDailyLog>();
 
 
     public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)

--- a/src/backend/DailyFitness.Infrastructure/Persistence/Mapping/TrainingPlanMapping.cs
+++ b/src/backend/DailyFitness.Infrastructure/Persistence/Mapping/TrainingPlanMapping.cs
@@ -1,0 +1,56 @@
+using DailyFitness.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DailyFitness.Infrastructure.Persistence.Mapping;
+
+public class TrainingPlanMapping : IEntityTypeConfiguration<TrainingPlan>
+{
+    public void Configure(EntityTypeBuilder<TrainingPlan> builder)
+    {
+        builder.ToTable("TrainingPlans");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Name)
+            .HasMaxLength(150)
+            .IsRequired();
+
+        builder.Property(x => x.Description)
+            .HasMaxLength(4000)
+            .IsRequired();
+
+        builder.Property(x => x.Objective)
+            .IsRequired();
+
+        builder.Property(x => x.Level)
+            .IsRequired();
+
+        builder.Property(x => x.Instructions)
+            .HasMaxLength(4000)
+            .IsRequired(false);
+
+        builder.Property(x => x.MinimumDurationDays)
+            .IsRequired();
+
+        builder.Property(x => x.CreatedByUserId)
+            .IsRequired(false);
+
+        builder.Property(x => x.Status)
+            .IsRequired();
+
+        builder.Property(x => x.CreatedAt)
+            .IsRequired();
+
+        builder.HasOne(x => x.CreatedByUser)
+            .WithMany()
+            .HasForeignKey(x => x.CreatedByUserId)
+            .IsRequired(false)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        builder.HasIndex(x => x.Objective);
+        builder.HasIndex(x => x.Level);
+        builder.HasIndex(x => x.Status);
+        builder.HasIndex(x => x.CreatedByUserId);
+    }
+}

--- a/src/backend/DailyFitness.Infrastructure/Persistence/Mapping/TrainingWorkoutItemMapping.cs
+++ b/src/backend/DailyFitness.Infrastructure/Persistence/Mapping/TrainingWorkoutItemMapping.cs
@@ -1,0 +1,53 @@
+using DailyFitness.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DailyFitness.Infrastructure.Persistence.Mapping;
+
+public class TrainingWorkoutItemMapping : IEntityTypeConfiguration<TrainingWorkoutItem>
+{
+    public void Configure(EntityTypeBuilder<TrainingWorkoutItem> builder)
+    {
+        builder.ToTable("TrainingWorkoutItems");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.TrainingWorkoutId)
+            .IsRequired();
+
+        builder.Property(x => x.Name)
+            .HasMaxLength(150)
+            .IsRequired();
+
+        builder.Property(x => x.Description)
+            .HasMaxLength(2000)
+            .IsRequired(false);
+
+        builder.Property(x => x.Instructions)
+            .HasMaxLength(4000)
+            .IsRequired(false);
+
+        builder.Property(x => x.Sets)
+            .IsRequired(false);
+
+        builder.Property(x => x.Repetitions)
+            .IsRequired(false);
+
+        builder.Property(x => x.Order)
+            .IsRequired();
+
+        builder.Property(x => x.Status)
+            .IsRequired();
+
+        builder.Property(x => x.CreatedAt)
+            .IsRequired();
+
+        builder.HasOne(x => x.TrainingWorkout)
+            .WithMany(x => x.Items)
+            .HasForeignKey(x => x.TrainingWorkoutId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(x => x.TrainingWorkoutId);
+        builder.HasIndex(x => new { x.TrainingWorkoutId, x.Order });
+    }
+}

--- a/src/backend/DailyFitness.Infrastructure/Persistence/Mapping/TrainingWorkoutMapping.cs
+++ b/src/backend/DailyFitness.Infrastructure/Persistence/Mapping/TrainingWorkoutMapping.cs
@@ -1,0 +1,47 @@
+using DailyFitness.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DailyFitness.Infrastructure.Persistence.Mapping;
+
+public class TrainingWorkoutMapping : IEntityTypeConfiguration<TrainingWorkout>
+{
+    public void Configure(EntityTypeBuilder<TrainingWorkout> builder)
+    {
+        builder.ToTable("TrainingWorkouts");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.TrainingPlanId)
+            .IsRequired();
+
+        builder.Property(x => x.Name)
+            .HasMaxLength(150)
+            .IsRequired();
+
+        builder.Property(x => x.Description)
+            .HasMaxLength(2000)
+            .IsRequired(false);
+
+        builder.Property(x => x.Instructions)
+            .HasMaxLength(4000)
+            .IsRequired(false);
+
+        builder.Property(x => x.Order)
+            .IsRequired();
+
+        builder.Property(x => x.Status)
+            .IsRequired();
+
+        builder.Property(x => x.CreatedAt)
+            .IsRequired();
+
+        builder.HasOne(x => x.TrainingPlan)
+            .WithMany(x => x.Workouts)
+            .HasForeignKey(x => x.TrainingPlanId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(x => x.TrainingPlanId);
+        builder.HasIndex(x => new { x.TrainingPlanId, x.Order });
+    }
+}

--- a/src/backend/DailyFitness.Infrastructure/Persistence/Mapping/UserTrainingPlanMapping.cs
+++ b/src/backend/DailyFitness.Infrastructure/Persistence/Mapping/UserTrainingPlanMapping.cs
@@ -1,0 +1,58 @@
+using DailyFitness.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DailyFitness.Infrastructure.Persistence.Mapping;
+
+public class UserTrainingPlanMapping : IEntityTypeConfiguration<UserTrainingPlan>
+{
+    public void Configure(EntityTypeBuilder<UserTrainingPlan> builder)
+    {
+        builder.ToTable("UserTrainingPlans");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.UserId)
+            .IsRequired();
+
+        builder.Property(x => x.TrainingPlanId)
+            .IsRequired();
+
+        builder.Property(x => x.UserTrainingPlanStatus)
+            .IsRequired();
+
+        builder.Property(x => x.StartedAt)
+            .IsRequired();
+
+        builder.Property(x => x.CancelledAt)
+            .IsRequired(false);
+
+        builder.Property(x => x.CompletedAt)
+            .IsRequired(false);
+
+        builder.Property(x => x.CancellationReason)
+            .HasMaxLength(1000)
+            .IsRequired(false);
+
+        builder.Property(x => x.Status)
+            .IsRequired();
+
+        builder.Property(x => x.CreatedAt)
+            .IsRequired();
+
+        builder.HasOne(x => x.User)
+            .WithMany()
+            .HasForeignKey(x => x.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(x => x.TrainingPlan)
+            .WithMany(x => x.UserTrainingPlans)
+            .HasForeignKey(x => x.TrainingPlanId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(x => x.UserId);
+        builder.HasIndex(x => x.TrainingPlanId);
+        builder.HasIndex(x => x.UserTrainingPlanStatus);
+        builder.HasIndex(x => new { x.UserId, x.UserTrainingPlanStatus });
+    }
+}

--- a/src/backend/DailyFitness.Infrastructure/Persistence/Mapping/UserTrainingProgressMapping.cs
+++ b/src/backend/DailyFitness.Infrastructure/Persistence/Mapping/UserTrainingProgressMapping.cs
@@ -1,0 +1,58 @@
+using DailyFitness.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DailyFitness.Infrastructure.Persistence.Mapping;
+
+public class UserTrainingProgressMapping : IEntityTypeConfiguration<UserTrainingProgress>
+{
+    public void Configure(EntityTypeBuilder<UserTrainingProgress> builder)
+    {
+        builder.ToTable("UserTrainingProgresses");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.UserTrainingPlanId)
+            .IsRequired();
+
+        builder.Property(x => x.TrainingWorkoutId)
+            .IsRequired();
+
+        builder.Property(x => x.TrainingWorkoutItemId)
+            .IsRequired();
+
+        builder.Property(x => x.ProgressDate)
+            .IsRequired();
+
+        builder.Property(x => x.CompletedAt)
+            .IsRequired();
+
+        builder.Property(x => x.Status)
+            .IsRequired();
+
+        builder.Property(x => x.CreatedAt)
+            .IsRequired();
+
+        builder.HasOne(x => x.UserTrainingPlan)
+            .WithMany(x => x.Progresses)
+            .HasForeignKey(x => x.UserTrainingPlanId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(x => x.TrainingWorkout)
+            .WithMany()
+            .HasForeignKey(x => x.TrainingWorkoutId)
+            .OnDelete(DeleteBehavior.NoAction);
+
+        builder.HasOne(x => x.TrainingWorkoutItem)
+            .WithMany()
+            .HasForeignKey(x => x.TrainingWorkoutItemId)
+            .OnDelete(DeleteBehavior.NoAction);
+
+        builder.HasIndex(x => x.UserTrainingPlanId);
+        builder.HasIndex(x => x.TrainingWorkoutId);
+
+        // Impede duplicidade: mesmo item, mesmo dia, mesmo plano
+        builder.HasIndex(x => new { x.UserTrainingPlanId, x.TrainingWorkoutItemId, x.ProgressDate })
+            .IsUnique();
+    }
+}

--- a/src/backend/DailyFitness.Infrastructure/Persistence/Mapping/UserTrainingWorkoutDailyLogMapping.cs
+++ b/src/backend/DailyFitness.Infrastructure/Persistence/Mapping/UserTrainingWorkoutDailyLogMapping.cs
@@ -1,0 +1,56 @@
+using DailyFitness.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DailyFitness.Infrastructure.Persistence.Mapping;
+
+public class UserTrainingWorkoutDailyLogMapping : IEntityTypeConfiguration<UserTrainingWorkoutDailyLog>
+{
+    public void Configure(EntityTypeBuilder<UserTrainingWorkoutDailyLog> builder)
+    {
+        builder.ToTable("UserTrainingWorkoutDailyLogs");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.UserTrainingPlanId)
+            .IsRequired();
+
+        builder.Property(x => x.TrainingWorkoutId)
+            .IsRequired();
+
+        builder.Property(x => x.ProgressDate)
+            .IsRequired();
+
+        builder.Property(x => x.ProgressPercentage)
+            .HasPrecision(5, 2)
+            .IsRequired();
+
+        builder.Property(x => x.IsFinished)
+            .IsRequired();
+
+        builder.Property(x => x.FinishedAt)
+            .IsRequired(false);
+
+        builder.Property(x => x.Status)
+            .IsRequired();
+
+        builder.Property(x => x.CreatedAt)
+            .IsRequired();
+
+        builder.HasOne(x => x.UserTrainingPlan)
+            .WithMany(x => x.DailyLogs)
+            .HasForeignKey(x => x.UserTrainingPlanId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(x => x.TrainingWorkout)
+            .WithMany()
+            .HasForeignKey(x => x.TrainingWorkoutId)
+            .OnDelete(DeleteBehavior.NoAction);
+
+        builder.HasIndex(x => x.UserTrainingPlanId);
+
+        // Um log por treino por dia por plano
+        builder.HasIndex(x => new { x.UserTrainingPlanId, x.TrainingWorkoutId, x.ProgressDate })
+            .IsUnique();
+    }
+}

--- a/src/backend/DailyFitness.Infrastructure/Repositories/TrainingPlanRepository.cs
+++ b/src/backend/DailyFitness.Infrastructure/Repositories/TrainingPlanRepository.cs
@@ -1,0 +1,67 @@
+using DailyFitness.Application.Interfaces.Repositories;
+using DailyFitness.Domain.Common;
+using DailyFitness.Domain.Entities;
+using DailyFitness.Domain.ValueObjects;
+using DailyFitness.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace DailyFitness.Infrastructure.Repositories;
+
+public class TrainingPlanRepository(AppDbContext context) : Repository<TrainingPlan>(context), ITrainingPlanRepository
+{
+    public async Task<TrainingPlan?> GetWithWorkoutsAndItems(Guid id, CancellationToken ct)
+    {
+        return await set
+            .Include(x => x.Workouts.Where(w => w.Status == EntityStatus.Active).OrderBy(w => w.Order))
+                .ThenInclude(w => w.Items.Where(i => i.Status == EntityStatus.Active).OrderBy(i => i.Order))
+            .FirstOrDefaultAsync(x => x.Id == id, ct);
+    }
+
+    public async Task<IEnumerable<TrainingPlan>> GetAllWithWorkouts(CancellationToken ct)
+    {
+        return await set
+            .Include(x => x.Workouts.OrderBy(w => w.Order))
+                .ThenInclude(w => w.Items.OrderBy(i => i.Order))
+            .Include(x => x.UserTrainingPlans)
+            .OrderByDescending(x => x.CreatedAt)
+            .ToListAsync(ct);
+    }
+
+    public async Task<IEnumerable<TrainingPlan>> GetActive(ETrainingObjective? objective, ETrainingLevel? level, CancellationToken ct)
+    {
+        var query = set
+            .Include(x => x.Workouts.Where(w => w.Status == EntityStatus.Active).OrderBy(w => w.Order))
+                .ThenInclude(w => w.Items.Where(i => i.Status == EntityStatus.Active).OrderBy(i => i.Order))
+            .Where(x => x.Status == EntityStatus.Active);
+
+        if (objective.HasValue)
+            query = query.Where(x => x.Objective == objective.Value);
+
+        if (level.HasValue)
+            query = query.Where(x => x.Level == level.Value);
+
+        return await query
+            .OrderByDescending(x => x.CreatedAt)
+            .ToListAsync(ct);
+    }
+
+    public async Task<IEnumerable<TrainingPlan>> GetByCreator(Guid creatorId, CancellationToken ct)
+    {
+        return await set
+            .Include(x => x.Workouts.OrderBy(w => w.Order))
+                .ThenInclude(w => w.Items.OrderBy(i => i.Order))
+            .Include(x => x.UserTrainingPlans)
+            .Where(x => x.CreatedByUserId == creatorId)
+            .OrderByDescending(x => x.CreatedAt)
+            .ToListAsync(ct);
+    }
+
+    public async Task<TrainingPlan?> GetWithWorkoutsAndItemsByCreator(Guid id, Guid creatorId, CancellationToken ct)
+    {
+        return await set
+            .Include(x => x.Workouts.OrderBy(w => w.Order))
+                .ThenInclude(w => w.Items.OrderBy(i => i.Order))
+            .Include(x => x.UserTrainingPlans)
+            .FirstOrDefaultAsync(x => x.Id == id && x.CreatedByUserId == creatorId, ct);
+    }
+}

--- a/src/backend/DailyFitness.Infrastructure/Repositories/UserTrainingPlanRepository.cs
+++ b/src/backend/DailyFitness.Infrastructure/Repositories/UserTrainingPlanRepository.cs
@@ -1,0 +1,63 @@
+using DailyFitness.Application.Interfaces.Repositories;
+using DailyFitness.Domain.Entities;
+using DailyFitness.Domain.ValueObjects;
+using DailyFitness.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace DailyFitness.Infrastructure.Repositories;
+
+public class UserTrainingPlanRepository(AppDbContext context) : Repository<UserTrainingPlan>(context), IUserTrainingPlanRepository
+{
+    public async Task<UserTrainingPlan?> GetActiveByUser(Guid userId, CancellationToken ct)
+    {
+        return await set
+            .Include(x => x.TrainingPlan)
+                .ThenInclude(p => p!.Workouts.OrderBy(w => w.Order))
+                    .ThenInclude(w => w.Items.OrderBy(i => i.Order))
+            .FirstOrDefaultAsync(x =>
+                x.UserId == userId &&
+                x.UserTrainingPlanStatus == EUserTrainingPlanStatus.Active, ct);
+    }
+
+    public async Task<UserTrainingPlan?> GetWithPlanAndProgress(Guid userTrainingPlanId, CancellationToken ct)
+    {
+        return await set
+            .Include(x => x.TrainingPlan)
+                .ThenInclude(p => p!.Workouts.OrderBy(w => w.Order))
+                    .ThenInclude(w => w.Items.OrderBy(i => i.Order))
+            .Include(x => x.Progresses)
+            .Include(x => x.DailyLogs)
+            .FirstOrDefaultAsync(x => x.Id == userTrainingPlanId, ct);
+    }
+
+    public async Task<IEnumerable<UserTrainingPlan>> GetByUser(Guid userId, CancellationToken ct)
+    {
+        return await set
+            .Include(x => x.TrainingPlan)
+            .Include(x => x.Progresses)
+            .Include(x => x.DailyLogs)
+            .Where(x => x.UserId == userId)
+            .OrderByDescending(x => x.StartedAt)
+            .ToListAsync(ct);
+    }
+
+    public async Task<IEnumerable<UserTrainingPlan>> GetByPlan(Guid trainingPlanId, CancellationToken ct)
+    {
+        return await set
+            .Include(x => x.User)
+            .Include(x => x.Progresses)
+            .Where(x => x.TrainingPlanId == trainingPlanId)
+            .OrderByDescending(x => x.StartedAt)
+            .ToListAsync(ct);
+    }
+
+    public async Task<IEnumerable<UserTrainingPlan>> GetByPlanWithUser(Guid trainingPlanId, CancellationToken ct)
+    {
+        return await set
+            .Include(x => x.User)
+            .Include(x => x.DailyLogs)
+            .Where(x => x.TrainingPlanId == trainingPlanId)
+            .OrderByDescending(x => x.StartedAt)
+            .ToListAsync(ct);
+    }
+}

--- a/src/backend/DailyFitness.Infrastructure/Repositories/UserTrainingProgressRepository.cs
+++ b/src/backend/DailyFitness.Infrastructure/Repositories/UserTrainingProgressRepository.cs
@@ -1,0 +1,40 @@
+using DailyFitness.Application.Interfaces.Repositories;
+using DailyFitness.Domain.Entities;
+using DailyFitness.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace DailyFitness.Infrastructure.Repositories;
+
+public class UserTrainingProgressRepository(AppDbContext context) : Repository<UserTrainingProgress>(context), IUserTrainingProgressRepository
+{
+    public async Task<UserTrainingProgress?> GetByPlanItemAndDate(Guid userTrainingPlanId, Guid trainingWorkoutItemId, DateTime progressDate, CancellationToken ct)
+    {
+        var date = progressDate.Date;
+
+        return await set
+            .FirstOrDefaultAsync(x =>
+                x.UserTrainingPlanId == userTrainingPlanId &&
+                x.TrainingWorkoutItemId == trainingWorkoutItemId &&
+                x.ProgressDate == date, ct);
+    }
+
+    public async Task<IEnumerable<UserTrainingProgress>> GetByPlanAndWorkoutAndDate(Guid userTrainingPlanId, Guid trainingWorkoutId, DateTime progressDate, CancellationToken ct)
+    {
+        var date = progressDate.Date;
+
+        return await set
+            .Where(x =>
+                x.UserTrainingPlanId == userTrainingPlanId &&
+                x.TrainingWorkoutId == trainingWorkoutId &&
+                x.ProgressDate == date)
+            .ToListAsync(ct);
+    }
+
+    public async Task<IEnumerable<UserTrainingProgress>> GetByUserTrainingPlan(Guid userTrainingPlanId, CancellationToken ct)
+    {
+        return await set
+            .Where(x => x.UserTrainingPlanId == userTrainingPlanId)
+            .OrderByDescending(x => x.ProgressDate)
+            .ToListAsync(ct);
+    }
+}

--- a/src/backend/DailyFitness.Infrastructure/Repositories/UserTrainingWorkoutDailyLogRepository.cs
+++ b/src/backend/DailyFitness.Infrastructure/Repositories/UserTrainingWorkoutDailyLogRepository.cs
@@ -1,0 +1,28 @@
+using DailyFitness.Application.Interfaces.Repositories;
+using DailyFitness.Domain.Entities;
+using DailyFitness.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace DailyFitness.Infrastructure.Repositories;
+
+public class UserTrainingWorkoutDailyLogRepository(AppDbContext context) : Repository<UserTrainingWorkoutDailyLog>(context), IUserTrainingWorkoutDailyLogRepository
+{
+    public async Task<UserTrainingWorkoutDailyLog?> GetByPlanWorkoutAndDate(Guid userTrainingPlanId, Guid trainingWorkoutId, DateTime progressDate, CancellationToken ct)
+    {
+        var date = progressDate.Date;
+
+        return await set
+            .FirstOrDefaultAsync(x =>
+                x.UserTrainingPlanId == userTrainingPlanId &&
+                x.TrainingWorkoutId == trainingWorkoutId &&
+                x.ProgressDate == date, ct);
+    }
+
+    public async Task<IEnumerable<UserTrainingWorkoutDailyLog>> GetByUserTrainingPlan(Guid userTrainingPlanId, CancellationToken ct)
+    {
+        return await set
+            .Where(x => x.UserTrainingPlanId == userTrainingPlanId)
+            .OrderByDescending(x => x.ProgressDate)
+            .ToListAsync(ct);
+    }
+}

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -29,6 +29,13 @@ import AdminChallengeDetail from "./pages/challenges/admin/AdminChallengeDetail.
 import ProfessionalChallengesList from "./pages/challenges/professional/ProfessionalChallengesList.tsx";
 import CreateProfessionalChallenge from "./pages/challenges/professional/CreateProfessionalChallenge.tsx";
 import ProfessionalChallengeDetail from "./pages/challenges/professional/ProfessionalChallengeDetail.tsx";
+import TrainingPlansList from "./pages/training-plans/TrainingPlansList.tsx";
+import TrainingPlanDetail from "./pages/training-plans/TrainingPlanDetail.tsx";
+import MyTrainingPlan from "./pages/training-plans/MyTrainingPlan.tsx";
+import TrainingPlanHistory from "./pages/training-plans/TrainingPlanHistory.tsx";
+import ManagementTrainingPlansList from "./pages/training-plans/management/ManagementTrainingPlansList.tsx";
+import ManagementTrainingPlanForm from "./pages/training-plans/management/ManagementTrainingPlanForm.tsx";
+import ManagementTrainingPlanDetail from "./pages/training-plans/management/ManagementTrainingPlanDetail.tsx";
 
 const queryClient = new QueryClient();
 
@@ -182,6 +189,108 @@ const App = () => (
             element={
               <RoleProtectedRoute allowedRoles={["Professional"]}>
                 <ProfessionalChallengeDetail />
+              </RoleProtectedRoute>
+            }
+          />
+
+          {/* Planos de Treino — User */}
+          <Route
+            path="/treinos"
+            element={
+              <ProtectedRoute>
+                <TrainingPlansList />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/treinos/meu-plano"
+            element={
+              <ProtectedRoute>
+                <MyTrainingPlan />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/treinos/historico"
+            element={
+              <ProtectedRoute>
+                <TrainingPlanHistory />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/treinos/:id"
+            element={
+              <ProtectedRoute>
+                <TrainingPlanDetail />
+              </ProtectedRoute>
+            }
+          />
+
+          {/* Planos de Treino — Admin */}
+          <Route
+            path="/treinos/gestao"
+            element={
+              <RoleProtectedRoute allowedRoles={["Administrator"]}>
+                <ManagementTrainingPlansList />
+              </RoleProtectedRoute>
+            }
+          />
+          <Route
+            path="/treinos/gestao/criar"
+            element={
+              <RoleProtectedRoute allowedRoles={["Administrator"]}>
+                <ManagementTrainingPlanForm />
+              </RoleProtectedRoute>
+            }
+          />
+          <Route
+            path="/treinos/gestao/:id"
+            element={
+              <RoleProtectedRoute allowedRoles={["Administrator"]}>
+                <ManagementTrainingPlanDetail />
+              </RoleProtectedRoute>
+            }
+          />
+          <Route
+            path="/treinos/gestao/:id/editar"
+            element={
+              <RoleProtectedRoute allowedRoles={["Administrator"]}>
+                <ManagementTrainingPlanForm />
+              </RoleProtectedRoute>
+            }
+          />
+
+          {/* Planos de Treino — Professional */}
+          <Route
+            path="/treinos/profissional"
+            element={
+              <RoleProtectedRoute allowedRoles={["Professional"]}>
+                <ManagementTrainingPlansList />
+              </RoleProtectedRoute>
+            }
+          />
+          <Route
+            path="/treinos/profissional/criar"
+            element={
+              <RoleProtectedRoute allowedRoles={["Professional"]}>
+                <ManagementTrainingPlanForm />
+              </RoleProtectedRoute>
+            }
+          />
+          <Route
+            path="/treinos/profissional/:id"
+            element={
+              <RoleProtectedRoute allowedRoles={["Professional"]}>
+                <ManagementTrainingPlanDetail />
+              </RoleProtectedRoute>
+            }
+          />
+          <Route
+            path="/treinos/profissional/:id/editar"
+            element={
+              <RoleProtectedRoute allowedRoles={["Professional"]}>
+                <ManagementTrainingPlanForm />
               </RoleProtectedRoute>
             }
           />

--- a/src/frontend/src/lib/training-plans-api.ts
+++ b/src/frontend/src/lib/training-plans-api.ts
@@ -1,0 +1,525 @@
+import { ApiResponse } from "./api";
+
+const API_BASE_URL = import.meta.env.VITE_API_URL ?? "";
+
+// ── Enums ──────────────────────────────────────────────────────────────────────
+
+export enum ETrainingObjective {
+  WeightLoss = 1,
+  MuscleGain = 2,
+  Endurance = 3,
+  Flexibility = 4,
+  GeneralFitness = 5,
+  Performance = 6,
+}
+
+export enum ETrainingLevel {
+  Beginner = 1,
+  Intermediate = 2,
+  Advanced = 3,
+}
+
+export enum EUserTrainingPlanStatus {
+  Active = 1,
+  Cancelled = 2,
+  Completed = 3,
+}
+
+// ── Labels ─────────────────────────────────────────────────────────────────────
+
+export const TrainingObjectiveLabel: Record<ETrainingObjective, string> = {
+  [ETrainingObjective.WeightLoss]: "Emagrecimento",
+  [ETrainingObjective.MuscleGain]: "Hipertrofia",
+  [ETrainingObjective.Endurance]: "Resistência",
+  [ETrainingObjective.Flexibility]: "Flexibilidade",
+  [ETrainingObjective.GeneralFitness]: "Condicionamento Geral",
+  [ETrainingObjective.Performance]: "Performance",
+};
+
+export const TrainingLevelLabel: Record<ETrainingLevel, string> = {
+  [ETrainingLevel.Beginner]: "Iniciante",
+  [ETrainingLevel.Intermediate]: "Intermediário",
+  [ETrainingLevel.Advanced]: "Avançado",
+};
+
+export const UserTrainingPlanStatusLabel: Record<EUserTrainingPlanStatus, string> = {
+  [EUserTrainingPlanStatus.Active]: "Ativo",
+  [EUserTrainingPlanStatus.Cancelled]: "Cancelado",
+  [EUserTrainingPlanStatus.Completed]: "Concluído",
+};
+
+// ── Response DTOs ──────────────────────────────────────────────────────────────
+
+export interface TrainingWorkoutItemDto {
+  id: string;
+  name: string;
+  description: string | null;
+  instructions: string | null;
+  sets: number | null;
+  repetitions: number | null;
+  order: number;
+  status: number;
+}
+
+export interface TrainingWorkoutDto {
+  id: string;
+  name: string;
+  description: string | null;
+  instructions: string | null;
+  order: number;
+  status: number;
+  items: TrainingWorkoutItemDto[];
+}
+
+export interface TrainingPlanDto {
+  id: string;
+  name: string;
+  description: string;
+  objective: ETrainingObjective;
+  level: ETrainingLevel;
+  instructions: string | null;
+  minimumDurationDays: number;
+  status: number; // 0=Inactive, 1=Active
+  createdByUserId: string | null;
+  subscriberCount: number;
+  activeSubscriberCount: number;
+  workouts: TrainingWorkoutDto[];
+  createdAt: string;
+  updatedAt: string | null;
+}
+
+export interface UserTrainingProgressDto {
+  id: string;
+  userTrainingPlanId: string;
+  trainingWorkoutId: string;
+  trainingWorkoutItemId: string;
+  progressDate: string;
+  completedAt: string;
+  createdAt: string;
+}
+
+export interface UserTrainingWorkoutDailyLogDto {
+  id: string;
+  userTrainingPlanId: string;
+  trainingWorkoutId: string;
+  progressDate: string;
+  progressPercentage: number;
+  isFinished: boolean;
+  finishedAt: string | null;
+  createdAt: string;
+}
+
+export interface UserTrainingPlanDto {
+  id: string;
+  userId: string;
+  userFullName: string;
+  trainingPlanId: string;
+  trainingPlanName: string;
+  userTrainingPlanStatus: EUserTrainingPlanStatus;
+  startedAt: string;
+  cancelledAt: string | null;
+  completedAt: string | null;
+  cancellationReason: string | null;
+  trainingPlan: TrainingPlanDto | null;
+  progresses: UserTrainingProgressDto[];
+  dailyLogs: UserTrainingWorkoutDailyLogDto[];
+  overallProgressPercentage: number;
+  totalItemsCompleted: number;
+  createdAt: string;
+  updatedAt: string | null;
+}
+
+export interface TrainingPlanSubscriberDto {
+  userTrainingPlanId: string;
+  userId: string;
+  userFullName: string;
+  status: EUserTrainingPlanStatus;
+  startedAt: string;
+  cancelledAt: string | null;
+  completedAt: string | null;
+  overallProgressPercentage: number;
+  dailyLogs: UserTrainingWorkoutDailyLogDto[];
+}
+
+// ── Request DTOs ───────────────────────────────────────────────────────────────
+
+export interface CreateTrainingWorkoutItemPayload {
+  name: string;
+  description?: string;
+  instructions?: string;
+  sets?: number;
+  repetitions?: number;
+  order: number;
+}
+
+export interface CreateTrainingWorkoutPayload {
+  name: string;
+  description?: string;
+  instructions?: string;
+  order: number;
+  items: CreateTrainingWorkoutItemPayload[];
+}
+
+export interface CreateTrainingPlanPayload {
+  name: string;
+  description: string;
+  objective: ETrainingObjective;
+  level: ETrainingLevel;
+  instructions?: string;
+  minimumDurationDays: number;
+  workouts: CreateTrainingWorkoutPayload[];
+}
+
+export interface UpsertTrainingWorkoutItemPayload {
+  id?: string;
+  name: string;
+  description?: string;
+  instructions?: string;
+  sets?: number;
+  repetitions?: number;
+  order: number;
+}
+
+export interface UpsertTrainingWorkoutPayload {
+  id?: string;
+  name: string;
+  description?: string;
+  instructions?: string;
+  order: number;
+  items: UpsertTrainingWorkoutItemPayload[];
+}
+
+export interface UpdateTrainingPlanPayload {
+  name: string;
+  description: string;
+  objective: ETrainingObjective;
+  level: ETrainingLevel;
+  instructions?: string;
+  minimumDurationDays: number;
+  workouts: UpsertTrainingWorkoutPayload[];
+}
+
+export interface CancelTrainingPlanPayload {
+  reason?: string;
+}
+
+export interface MarkTrainingItemProgressPayload {
+  progressDate?: string; // ISO date
+}
+
+// ── Helpers internos ───────────────────────────────────────────────────────────
+
+function getAuthHeader(): Record<string, string> {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("auth_token") : null;
+  if (!token) return {};
+  return { Authorization: `Bearer ${token}` };
+}
+
+async function parseApiResponse<T>(
+  response: Response,
+  context: string
+): Promise<ApiResponse<T>> {
+  const text = await response.text();
+  let parsed: ApiResponse<T> | null = null;
+
+  if (text) {
+    try {
+      parsed = JSON.parse(text) as ApiResponse<T>;
+    } catch {
+      // not JSON
+    }
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      parsed?.message || `Erro em ${context}. Código: ${response.status}`
+    );
+  }
+
+  if (!parsed) {
+    throw new Error(`Resposta da API (${context}) não é JSON válido`);
+  }
+
+  return {
+    success: Boolean(parsed.success),
+    message: parsed.message ?? "",
+    data: parsed.data ?? null,
+  };
+}
+
+const BASE = `${API_BASE_URL}/TrainingPlans`;
+const HEADERS = () => ({
+  "Content-Type": "application/json",
+  ...getAuthHeader(),
+});
+
+// ── User — Listagem pública ────────────────────────────────────────────────────
+
+export async function getAvailableTrainingPlans(
+  objective?: ETrainingObjective,
+  level?: ETrainingLevel
+): Promise<ApiResponse<TrainingPlanDto[]>> {
+  const params = new URLSearchParams();
+  if (objective !== undefined) params.append("objective", String(objective));
+  if (level !== undefined) params.append("level", String(level));
+  const qs = params.toString() ? `?${params.toString()}` : "";
+
+  const res = await fetch(`${BASE}${qs}`, { method: "GET", headers: HEADERS() });
+  return parseApiResponse<TrainingPlanDto[]>(res, "getAvailableTrainingPlans");
+}
+
+export async function getTrainingPlanDetail(
+  id: string
+): Promise<ApiResponse<TrainingPlanDto>> {
+  const res = await fetch(`${BASE}/${encodeURIComponent(id)}`, {
+    method: "GET",
+    headers: HEADERS(),
+  });
+  return parseApiResponse<TrainingPlanDto>(res, "getTrainingPlanDetail");
+}
+
+// ── User — Inscrição ──────────────────────────────────────────────────────────
+
+export async function subscribeTrainingPlan(
+  id: string
+): Promise<ApiResponse<UserTrainingPlanDto>> {
+  const res = await fetch(`${BASE}/${encodeURIComponent(id)}/subscribe`, {
+    method: "POST",
+    headers: HEADERS(),
+  });
+  return parseApiResponse<UserTrainingPlanDto>(res, "subscribeTrainingPlan");
+}
+
+// ── User — Plano atual ────────────────────────────────────────────────────────
+
+export async function getCurrentTrainingPlan(): Promise<ApiResponse<UserTrainingPlanDto>> {
+  const res = await fetch(`${BASE}/current`, { method: "GET", headers: HEADERS() });
+  return parseApiResponse<UserTrainingPlanDto>(res, "getCurrentTrainingPlan");
+}
+
+export async function getCurrentTrainingPlanProgress(): Promise<ApiResponse<UserTrainingPlanDto>> {
+  const res = await fetch(`${BASE}/current/progress`, {
+    method: "GET",
+    headers: HEADERS(),
+  });
+  return parseApiResponse<UserTrainingPlanDto>(res, "getCurrentTrainingPlanProgress");
+}
+
+export async function cancelTrainingPlan(
+  payload: CancelTrainingPlanPayload
+): Promise<ApiResponse<UserTrainingPlanDto>> {
+  const res = await fetch(`${BASE}/current/cancel`, {
+    method: "POST",
+    headers: HEADERS(),
+    body: JSON.stringify(payload),
+  });
+  return parseApiResponse<UserTrainingPlanDto>(res, "cancelTrainingPlan");
+}
+
+export async function markItemProgress(
+  workoutId: string,
+  itemId: string,
+  payload: MarkTrainingItemProgressPayload = {}
+): Promise<ApiResponse<UserTrainingPlanDto>> {
+  const res = await fetch(
+    `${BASE}/current/workouts/${encodeURIComponent(workoutId)}/items/${encodeURIComponent(itemId)}/complete`,
+    {
+      method: "POST",
+      headers: HEADERS(),
+      body: JSON.stringify(payload),
+    }
+  );
+  return parseApiResponse<UserTrainingPlanDto>(res, "markItemProgress");
+}
+
+export async function finishWorkoutDay(
+  workoutId: string
+): Promise<ApiResponse<UserTrainingWorkoutDailyLogDto>> {
+  const res = await fetch(
+    `${BASE}/current/workouts/${encodeURIComponent(workoutId)}/finish-day`,
+    {
+      method: "POST",
+      headers: HEADERS(),
+    }
+  );
+  return parseApiResponse<UserTrainingWorkoutDailyLogDto>(res, "finishWorkoutDay");
+}
+
+// ── User — Histórico ──────────────────────────────────────────────────────────
+
+export async function getTrainingPlanHistory(): Promise<ApiResponse<UserTrainingPlanDto[]>> {
+  const res = await fetch(`${BASE}/history`, {
+    method: "GET",
+    headers: HEADERS(),
+  });
+  return parseApiResponse<UserTrainingPlanDto[]>(res, "getTrainingPlanHistory");
+}
+
+// ── Admin — Gestão ────────────────────────────────────────────────────────────
+
+export async function adminGetAllTrainingPlans(): Promise<ApiResponse<TrainingPlanDto[]>> {
+  const res = await fetch(`${BASE}/management`, {
+    method: "GET",
+    headers: HEADERS(),
+  });
+  return parseApiResponse<TrainingPlanDto[]>(res, "adminGetAllTrainingPlans");
+}
+
+export async function adminGetTrainingPlan(
+  id: string
+): Promise<ApiResponse<TrainingPlanDto>> {
+  const res = await fetch(`${BASE}/management/${encodeURIComponent(id)}`, {
+    method: "GET",
+    headers: HEADERS(),
+  });
+  return parseApiResponse<TrainingPlanDto>(res, "adminGetTrainingPlan");
+}
+
+export async function adminCreateTrainingPlan(
+  payload: CreateTrainingPlanPayload
+): Promise<ApiResponse<TrainingPlanDto>> {
+  const res = await fetch(`${BASE}/management`, {
+    method: "POST",
+    headers: HEADERS(),
+    body: JSON.stringify(payload),
+  });
+  return parseApiResponse<TrainingPlanDto>(res, "adminCreateTrainingPlan");
+}
+
+export async function adminUpdateTrainingPlan(
+  id: string,
+  payload: UpdateTrainingPlanPayload
+): Promise<ApiResponse<TrainingPlanDto>> {
+  const res = await fetch(`${BASE}/management/${encodeURIComponent(id)}`, {
+    method: "PUT",
+    headers: HEADERS(),
+    body: JSON.stringify(payload),
+  });
+  return parseApiResponse<TrainingPlanDto>(res, "adminUpdateTrainingPlan");
+}
+
+export async function adminActivateTrainingPlan(
+  id: string
+): Promise<ApiResponse<TrainingPlanDto>> {
+  const res = await fetch(
+    `${BASE}/management/${encodeURIComponent(id)}/activate`,
+    { method: "PATCH", headers: HEADERS() }
+  );
+  return parseApiResponse<TrainingPlanDto>(res, "adminActivateTrainingPlan");
+}
+
+export async function adminDeactivateTrainingPlan(
+  id: string
+): Promise<ApiResponse<TrainingPlanDto>> {
+  const res = await fetch(
+    `${BASE}/management/${encodeURIComponent(id)}/deactivate`,
+    { method: "PATCH", headers: HEADERS() }
+  );
+  return parseApiResponse<TrainingPlanDto>(res, "adminDeactivateTrainingPlan");
+}
+
+export async function adminGetPlanSubscribers(
+  id: string
+): Promise<ApiResponse<TrainingPlanSubscriberDto[]>> {
+  const res = await fetch(
+    `${BASE}/management/${encodeURIComponent(id)}/subscribers`,
+    { method: "GET", headers: HEADERS() }
+  );
+  return parseApiResponse<TrainingPlanSubscriberDto[]>(res, "adminGetPlanSubscribers");
+}
+
+export async function adminGetSubscriberProgress(
+  planId: string,
+  userId: string
+): Promise<ApiResponse<UserTrainingPlanDto>> {
+  const res = await fetch(
+    `${BASE}/management/${encodeURIComponent(planId)}/subscribers/${encodeURIComponent(userId)}/progress`,
+    { method: "GET", headers: HEADERS() }
+  );
+  return parseApiResponse<UserTrainingPlanDto>(res, "adminGetSubscriberProgress");
+}
+
+// ── Professional — Gestão ─────────────────────────────────────────────────────
+
+export async function profGetManagedPlans(): Promise<ApiResponse<TrainingPlanDto[]>> {
+  const res = await fetch(`${BASE}/managed`, {
+    method: "GET",
+    headers: HEADERS(),
+  });
+  return parseApiResponse<TrainingPlanDto[]>(res, "profGetManagedPlans");
+}
+
+export async function profGetManagedPlan(
+  id: string
+): Promise<ApiResponse<TrainingPlanDto>> {
+  const res = await fetch(`${BASE}/managed/${encodeURIComponent(id)}`, {
+    method: "GET",
+    headers: HEADERS(),
+  });
+  return parseApiResponse<TrainingPlanDto>(res, "profGetManagedPlan");
+}
+
+export async function profCreateManagedPlan(
+  payload: CreateTrainingPlanPayload
+): Promise<ApiResponse<TrainingPlanDto>> {
+  const res = await fetch(`${BASE}/managed`, {
+    method: "POST",
+    headers: HEADERS(),
+    body: JSON.stringify(payload),
+  });
+  return parseApiResponse<TrainingPlanDto>(res, "profCreateManagedPlan");
+}
+
+export async function profUpdateManagedPlan(
+  id: string,
+  payload: UpdateTrainingPlanPayload
+): Promise<ApiResponse<TrainingPlanDto>> {
+  const res = await fetch(`${BASE}/managed/${encodeURIComponent(id)}`, {
+    method: "PUT",
+    headers: HEADERS(),
+    body: JSON.stringify(payload),
+  });
+  return parseApiResponse<TrainingPlanDto>(res, "profUpdateManagedPlan");
+}
+
+export async function profActivateManagedPlan(
+  id: string
+): Promise<ApiResponse<TrainingPlanDto>> {
+  const res = await fetch(
+    `${BASE}/managed/${encodeURIComponent(id)}/activate`,
+    { method: "PATCH", headers: HEADERS() }
+  );
+  return parseApiResponse<TrainingPlanDto>(res, "profActivateManagedPlan");
+}
+
+export async function profDeactivateManagedPlan(
+  id: string
+): Promise<ApiResponse<TrainingPlanDto>> {
+  const res = await fetch(
+    `${BASE}/managed/${encodeURIComponent(id)}/deactivate`,
+    { method: "PATCH", headers: HEADERS() }
+  );
+  return parseApiResponse<TrainingPlanDto>(res, "profDeactivateManagedPlan");
+}
+
+export async function profGetManagedPlanSubscribers(
+  id: string
+): Promise<ApiResponse<TrainingPlanSubscriberDto[]>> {
+  const res = await fetch(
+    `${BASE}/managed/${encodeURIComponent(id)}/subscribers`,
+    { method: "GET", headers: HEADERS() }
+  );
+  return parseApiResponse<TrainingPlanSubscriberDto[]>(res, "profGetManagedPlanSubscribers");
+}
+
+export async function profGetManagedSubscriberProgress(
+  planId: string,
+  subscriberUserId: string
+): Promise<ApiResponse<UserTrainingPlanDto>> {
+  const res = await fetch(
+    `${BASE}/managed/${encodeURIComponent(planId)}/subscribers/${encodeURIComponent(subscriberUserId)}/progress`,
+    { method: "GET", headers: HEADERS() }
+  );
+  return parseApiResponse<UserTrainingPlanDto>(res, "profGetManagedSubscriberProgress");
+}

--- a/src/frontend/src/pages/training-plans/MyTrainingPlan.tsx
+++ b/src/frontend/src/pages/training-plans/MyTrainingPlan.tsx
@@ -1,0 +1,309 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  Dumbbell,
+  Loader2,
+  AlertCircle,
+  CheckCircle2,
+  Circle,
+  XCircle,
+  RefreshCw,
+} from "lucide-react";
+import { toast } from "sonner";
+import DashboardHeader from "@/components/DashboardHeader";
+import {
+  getCurrentTrainingPlan,
+  cancelTrainingPlan,
+  markItemProgress,
+  finishWorkoutDay,
+  UserTrainingPlanDto,
+  TrainingObjectiveLabel,
+  TrainingLevelLabel,
+  EUserTrainingPlanStatus,
+} from "@/lib/training-plans-api";
+
+const MyTrainingPlan = () => {
+  const [utp, setUtp] = useState<UserTrainingPlanDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [loadingItemId, setLoadingItemId] = useState<string | null>(null);
+  const [loadingWorkoutFinish, setLoadingWorkoutFinish] = useState<string | null>(null);
+  const [cancelling, setCancelling] = useState(false);
+
+  const todayDate = new Date().toISOString().split("T")[0];
+
+  const load = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const res = await getCurrentTrainingPlan();
+      setUtp(res.data ?? null);
+    } catch {
+      setUtp(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  // Itens completados hoje neste plano (por workoutItem + workoutId)
+  const completedTodaySet = new Set(
+    (utp?.progresses ?? [])
+      .filter((p) => p.progressDate.startsWith(todayDate))
+      .map((p) => `${p.trainingWorkoutId}:${p.trainingWorkoutItemId}`)
+  );
+
+  const getDailyLog = (workoutId: string) =>
+    utp?.dailyLogs.find(
+      (l) => l.trainingWorkoutId === workoutId && l.progressDate.startsWith(todayDate)
+    );
+
+  const handleMarkItem = async (workoutId: string, itemId: string) => {
+    const key = `${workoutId}:${itemId}`;
+    if (completedTodaySet.has(key)) return;
+
+    setLoadingItemId(key);
+    try {
+      const res = await markItemProgress(workoutId, itemId, {
+        progressDate: todayDate,
+      });
+      setUtp(res.data!);
+      toast.success("Exercício marcado como concluído!");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Erro ao registrar progresso.");
+    } finally {
+      setLoadingItemId(null);
+    }
+  };
+
+  const handleFinishDay = async (workoutId: string) => {
+    setLoadingWorkoutFinish(workoutId);
+    try {
+      await finishWorkoutDay(workoutId);
+      toast.success("Treino do dia finalizado!");
+      load();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Erro ao finalizar treino.");
+    } finally {
+      setLoadingWorkoutFinish(null);
+    }
+  };
+
+  const handleCancel = async () => {
+    if (!confirm("Tem certeza que deseja cancelar este plano de treino?")) return;
+    setCancelling(true);
+    try {
+      await cancelTrainingPlan({});
+      toast.success("Plano cancelado.", { description: "Você pode se inscrever em outro plano." });
+      setUtp(null);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Erro ao cancelar plano.");
+    } finally {
+      setCancelling(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen px-4 md:px-[5%] py-5">
+        <DashboardHeader />
+        <div className="flex items-center justify-center min-h-[60vh]">
+          <Loader2 className="w-8 h-8 animate-spin text-primary" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!utp || utp.userTrainingPlanStatus !== EUserTrainingPlanStatus.Active) {
+    return (
+      <div className="min-h-screen px-4 md:px-[5%] py-5">
+        <DashboardHeader />
+        <main className="w-full max-w-3xl mx-auto pt-6 space-y-6 animate-fade-in">
+          <h2 className="text-2xl font-semibold">Meu Plano de Treino</h2>
+          <div className="glass-card rounded-2xl p-12 flex flex-col items-center gap-4 text-muted-foreground">
+            <div className="w-16 h-16 rounded-2xl bg-secondary flex items-center justify-center">
+              <Dumbbell className="w-8 h-8" />
+            </div>
+            <div className="text-center">
+              <p className="font-medium text-foreground">Nenhum plano ativo</p>
+              <p className="text-sm mt-1">Você não possui um plano de treino ativo no momento.</p>
+            </div>
+            <Link
+              to="/treinos"
+              className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium text-primary-foreground hover:opacity-90"
+              style={{ background: "var(--gradient-primary)" }}
+            >
+              Explorar Planos
+            </Link>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  const plan = utp.trainingPlan!;
+
+  return (
+    <div className="min-h-screen px-4 md:px-[5%] py-5">
+      <DashboardHeader />
+      <main className="w-full max-w-3xl mx-auto space-y-6 animate-fade-in">
+        {/* Header */}
+        <div className="flex items-center justify-between flex-wrap gap-3">
+          <div>
+            <h2 className="text-2xl font-semibold">Meu Plano de Treino</h2>
+            <p className="text-sm text-muted-foreground mt-1">Treino de hoje</p>
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={load}
+              disabled={loading}
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50"
+            >
+              <RefreshCw className={`w-4 h-4 ${loading ? "animate-spin" : ""}`} />
+            </button>
+            <Link to="/treinos/historico" className="px-3 py-1.5 rounded-lg text-xs border border-border text-muted-foreground hover:text-foreground hover:border-primary/50 transition-all">
+              Histórico
+            </Link>
+          </div>
+        </div>
+
+        {/* Plan summary */}
+        <div className="glass-card rounded-2xl p-5 space-y-3">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-xl flex items-center justify-center" style={{ background: "var(--gradient-primary)" }}>
+              <Dumbbell className="w-5 h-5 text-primary-foreground" />
+            </div>
+            <div>
+              <p className="font-semibold text-sm">{plan.name}</p>
+              <div className="flex gap-2 mt-1">
+                <span className="text-xs text-muted-foreground">{TrainingObjectiveLabel[plan.objective]}</span>
+                <span className="text-xs text-muted-foreground">·</span>
+                <span className="text-xs text-muted-foreground">{TrainingLevelLabel[plan.level]}</span>
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>Início: {new Date(utp.startedAt).toLocaleDateString("pt-BR")}</span>
+            <span>Progresso geral: <span className="text-primary font-medium">{utp.overallProgressPercentage.toFixed(1)}%</span></span>
+          </div>
+          <button
+            type="button"
+            onClick={handleCancel}
+            disabled={cancelling}
+            className="w-full inline-flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-xs font-medium text-destructive border border-destructive/30 hover:bg-destructive/10 transition-colors disabled:opacity-60"
+          >
+            {cancelling ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <XCircle className="w-3.5 h-3.5" />}
+            Cancelar inscrição
+          </button>
+        </div>
+
+        {/* Workouts */}
+        {plan.workouts.map((workout) => {
+          const log = getDailyLog(workout.id);
+          const isFinished = log?.isFinished ?? false;
+          const progressPct = log?.progressPercentage ?? 0;
+          const allCompleted = workout.items.filter(i => i.status === 1).every(
+            (item) => completedTodaySet.has(`${workout.id}:${item.id}`)
+          );
+
+          return (
+            <div key={workout.id} className="glass-card rounded-xl p-5 space-y-4">
+              <div className="flex items-center justify-between gap-2">
+                <div>
+                  <p className="font-semibold text-sm">{workout.order}. {workout.name}</p>
+                  {workout.description && <p className="text-xs text-muted-foreground mt-0.5">{workout.description}</p>}
+                </div>
+                <div className="text-right shrink-0">
+                  {isFinished ? (
+                    <span className="px-2 py-1 rounded-full text-xs bg-emerald-500/10 text-emerald-400 border border-emerald-500/30">
+                      ✓ Concluído
+                    </span>
+                  ) : (
+                    <span className="text-xs text-primary font-medium">{progressPct.toFixed(0)}%</span>
+                  )}
+                </div>
+              </div>
+
+              {/* Progress bar */}
+              <div className="w-full bg-secondary rounded-full h-1.5">
+                <div
+                  className="h-1.5 rounded-full transition-all duration-500"
+                  style={{ width: `${progressPct}%`, background: "var(--gradient-primary)" }}
+                />
+              </div>
+
+              {/* Items */}
+              <div className="space-y-2">
+                {workout.items.filter(i => i.status === 1).map((item) => {
+                  const key = `${workout.id}:${item.id}`;
+                  const done = completedTodaySet.has(key);
+                  const isLoading = loadingItemId === key;
+
+                  return (
+                    <button
+                      key={item.id}
+                      type="button"
+                      onClick={() => handleMarkItem(workout.id, item.id)}
+                      disabled={done || isLoading || isFinished}
+                      className={`w-full flex items-start gap-3 text-left p-3 rounded-lg border transition-all ${
+                        done
+                          ? "border-emerald-500/30 bg-emerald-500/5"
+                          : "border-border hover:border-primary/50 hover:bg-secondary/50"
+                      } disabled:cursor-not-allowed`}
+                    >
+                      {isLoading ? (
+                        <Loader2 className="w-4 h-4 animate-spin text-primary shrink-0 mt-0.5" />
+                      ) : done ? (
+                        <CheckCircle2 className="w-4 h-4 text-emerald-400 shrink-0 mt-0.5" />
+                      ) : (
+                        <Circle className="w-4 h-4 text-muted-foreground shrink-0 mt-0.5" />
+                      )}
+                      <div className="flex-1 min-w-0">
+                        <p className={`text-xs font-medium ${done ? "line-through text-muted-foreground" : "text-foreground"}`}>
+                          {item.name}
+                        </p>
+                        {(item.sets || item.repetitions) && (
+                          <p className="text-xs text-primary mt-0.5">
+                            {item.sets && `${item.sets}x`}{item.repetitions && ` ${item.repetitions} reps`}
+                          </p>
+                        )}
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+
+              {/* Finish workout day */}
+              {!isFinished && allCompleted && (
+                <button
+                  type="button"
+                  onClick={() => handleFinishDay(workout.id)}
+                  disabled={loadingWorkoutFinish === workout.id}
+                  className="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-60"
+                  style={{ background: "var(--gradient-primary)" }}
+                >
+                  {loadingWorkoutFinish === workout.id ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  ) : (
+                    <CheckCircle2 className="w-4 h-4" />
+                  )}
+                  Finalizar Treino do Dia
+                </button>
+              )}
+            </div>
+          );
+        })}
+
+        {error && (
+          <div className="rounded-xl bg-destructive/10 border border-destructive/30 px-4 py-3 text-sm text-destructive flex gap-2">
+            <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" /> {error}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default MyTrainingPlan;

--- a/src/frontend/src/pages/training-plans/TrainingPlanDetail.tsx
+++ b/src/frontend/src/pages/training-plans/TrainingPlanDetail.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams, Link } from "react-router-dom";
+import { Dumbbell, Loader2, AlertCircle, ChevronLeft, CheckCircle2 } from "lucide-react";
+import { toast } from "sonner";
+import DashboardHeader from "@/components/DashboardHeader";
+import {
+  getTrainingPlanDetail,
+  subscribeTrainingPlan,
+  getCurrentTrainingPlan,
+  TrainingPlanDto,
+  TrainingObjectiveLabel,
+  TrainingLevelLabel,
+} from "@/lib/training-plans-api";
+
+const TrainingPlanDetail = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const [plan, setPlan] = useState<TrainingPlanDto | null>(null);
+  const [hasActivePlan, setHasActivePlan] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [subscribing, setSubscribing] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const loadData = async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const [planRes, currentRes] = await Promise.allSettled([
+          getTrainingPlanDetail(id!),
+          getCurrentTrainingPlan(),
+        ]);
+
+        if (planRes.status === "fulfilled" && planRes.value.data) {
+          setPlan(planRes.value.data);
+        } else {
+          setError("Plano não encontrado.");
+        }
+
+        if (currentRes.status === "fulfilled" && currentRes.value.data) {
+          setHasActivePlan(true);
+        }
+      } catch {
+        setError("Erro ao carregar dados.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (id) loadData();
+  }, [id]);
+
+  const handleSubscribe = async () => {
+    if (!plan) return;
+    setSubscribing(true);
+    try {
+      await subscribeTrainingPlan(plan.id);
+      toast.success("Inscrição realizada!", {
+        description: `Você se inscreveu no plano "${plan.name}".`,
+      });
+      navigate("/treinos/meu-plano");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Erro ao se inscrever.");
+    } finally {
+      setSubscribing(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen px-4 md:px-[5%] py-5">
+        <DashboardHeader />
+        <div className="flex items-center justify-center min-h-[60vh]">
+          <Loader2 className="w-8 h-8 animate-spin text-primary" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !plan) {
+    return (
+      <div className="min-h-screen px-4 md:px-[5%] py-5">
+        <DashboardHeader />
+        <main className="w-full max-w-3xl mx-auto pt-6">
+          <div className="glass-card rounded-2xl p-6">
+            <div className="rounded-xl bg-destructive/10 border border-destructive/30 px-4 py-4 text-sm text-destructive flex items-start gap-3">
+              <AlertCircle className="w-5 h-5 shrink-0 mt-0.5" />
+              <p>{error || "Plano não encontrado."}</p>
+            </div>
+            <Link to="/treinos" className="mt-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+              <ChevronLeft className="w-4 h-4" /> Voltar aos planos
+            </Link>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen px-4 md:px-[5%] py-5">
+      <DashboardHeader />
+      <main className="w-full max-w-3xl mx-auto space-y-6 animate-fade-in">
+        {/* Back */}
+        <Link to="/treinos" className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors">
+          <ChevronLeft className="w-4 h-4" /> Voltar aos planos
+        </Link>
+
+        {/* Plan Header */}
+        <div className="glass-card rounded-2xl p-6 space-y-4">
+          <div className="flex items-start gap-4">
+            <div
+              className="w-12 h-12 rounded-xl flex items-center justify-center shrink-0"
+              style={{ background: "var(--gradient-primary)" }}
+            >
+              <Dumbbell className="w-6 h-6 text-primary-foreground" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <h2 className="text-xl font-semibold">{plan.name}</h2>
+              <div className="flex flex-wrap gap-2 mt-2">
+                <span className="px-2.5 py-0.5 rounded-full text-xs border bg-primary/10 text-primary border-primary/30">
+                  {TrainingObjectiveLabel[plan.objective]}
+                </span>
+                <span className="px-2.5 py-0.5 rounded-full text-xs border bg-secondary text-muted-foreground border-border">
+                  {TrainingLevelLabel[plan.level]}
+                </span>
+                <span className="px-2.5 py-0.5 rounded-full text-xs border bg-secondary text-muted-foreground border-border">
+                  ⏱ {plan.minimumDurationDays} dias mín.
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <p className="text-sm text-muted-foreground leading-relaxed">{plan.description}</p>
+
+          {plan.instructions && (
+            <div className="rounded-xl bg-secondary/50 border border-border p-4">
+              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1">Instruções</p>
+              <p className="text-sm text-foreground">{plan.instructions}</p>
+            </div>
+          )}
+
+          {/* Subscription CTA */}
+          {hasActivePlan ? (
+            <div className="rounded-xl bg-amber-500/10 border border-amber-500/30 px-4 py-3 text-sm text-amber-400 flex items-start gap-2">
+              <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
+              <span>
+                Você já possui um plano de treino ativo.{" "}
+                <Link to="/treinos/meu-plano" className="underline">
+                  Acesse e cancele o plano atual
+                </Link>{" "}
+                antes de se inscrever em outro.
+              </span>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={handleSubscribe}
+              disabled={subscribing}
+              className="w-full inline-flex items-center justify-center gap-2 px-4 py-3 rounded-xl text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-60"
+              style={{ background: "var(--gradient-primary)" }}
+            >
+              {subscribing ? (
+                <><Loader2 className="w-4 h-4 animate-spin" /> Inscrevendo...</>
+              ) : (
+                "Inscrever-se neste plano"
+              )}
+            </button>
+          )}
+        </div>
+
+        {/* Workouts */}
+        {plan.workouts && plan.workouts.length > 0 && (
+          <div className="space-y-4">
+            <h3 className="text-lg font-semibold">Treinos do Plano</h3>
+            {plan.workouts.map((workout) => (
+              <div key={workout.id} className="glass-card rounded-xl p-5 space-y-3">
+                <div>
+                  <p className="font-medium text-sm">
+                    {workout.order}. {workout.name}
+                  </p>
+                  {workout.description && (
+                    <p className="text-xs text-muted-foreground mt-1">{workout.description}</p>
+                  )}
+                  {workout.instructions && (
+                    <p className="text-xs text-primary/80 mt-1 italic">{workout.instructions}</p>
+                  )}
+                </div>
+
+                {workout.items && workout.items.length > 0 && (
+                  <div className="space-y-2 pt-2 border-t border-border">
+                    {workout.items.map((item) => (
+                      <div key={item.id} className="flex items-start gap-2 text-xs text-muted-foreground">
+                        <CheckCircle2 className="w-3.5 h-3.5 text-primary/50 mt-0.5 shrink-0" />
+                        <div>
+                          <span className="text-foreground font-medium">{item.name}</span>
+                          {(item.sets || item.repetitions) && (
+                            <span className="ml-2 text-primary">
+                              {item.sets && `${item.sets} séries`}
+                              {item.sets && item.repetitions && " × "}
+                              {item.repetitions && `${item.repetitions} reps`}
+                            </span>
+                          )}
+                          {item.instructions && (
+                            <p className="mt-0.5 italic">{item.instructions}</p>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default TrainingPlanDetail;

--- a/src/frontend/src/pages/training-plans/TrainingPlanHistory.tsx
+++ b/src/frontend/src/pages/training-plans/TrainingPlanHistory.tsx
@@ -1,0 +1,288 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  Dumbbell,
+  Loader2,
+  AlertCircle,
+  RefreshCw,
+  CalendarDays,
+  TrendingUp,
+  ChevronRight,
+  Plus,
+} from "lucide-react";
+import DashboardHeader from "@/components/DashboardHeader";
+import {
+  getTrainingPlanHistory,
+  UserTrainingPlanDto,
+  EUserTrainingPlanStatus,
+  UserTrainingPlanStatusLabel,
+  TrainingObjectiveLabel,
+  TrainingLevelLabel,
+} from "@/lib/training-plans-api";
+
+const statusStyles: Record<EUserTrainingPlanStatus, string> = {
+  [EUserTrainingPlanStatus.Active]:
+    "bg-emerald-500/10 text-emerald-400 border-emerald-500/30",
+  [EUserTrainingPlanStatus.Cancelled]:
+    "bg-secondary text-muted-foreground border-border",
+  [EUserTrainingPlanStatus.Completed]:
+    "bg-blue-500/10 text-blue-400 border-blue-500/30",
+};
+
+const TrainingPlanHistory = () => {
+  const [history, setHistory] = useState<UserTrainingPlanDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const load = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const res = await getTrainingPlanHistory();
+      setHistory(res.data ?? []);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Erro ao carregar histórico."
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const active = history.filter(
+    (h) => h.userTrainingPlanStatus === EUserTrainingPlanStatus.Active
+  );
+  const past = history.filter(
+    (h) => h.userTrainingPlanStatus !== EUserTrainingPlanStatus.Active
+  );
+
+  return (
+    <div className="min-h-screen px-4 md:px-[5%] py-5">
+      <DashboardHeader />
+      <main className="w-full max-w-4xl mx-auto space-y-6 animate-fade-in">
+        {/* Header */}
+        <div className="flex items-center justify-between flex-wrap gap-3">
+          <div>
+            <h2 className="text-2xl font-semibold">Histórico de Treinos</h2>
+            <p className="text-sm text-muted-foreground mt-1">
+              Todos os seus planos de treino
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={load}
+              disabled={loading}
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+            >
+              <RefreshCw className={`w-4 h-4 ${loading ? "animate-spin" : ""}`} />
+              Atualizar
+            </button>
+            <Link
+              to="/treinos/meu-plano"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium border border-border text-muted-foreground hover:text-foreground hover:border-primary/50 transition-all"
+            >
+              <Dumbbell className="w-4 h-4" />
+              Meu Plano
+            </Link>
+            <Link
+              to="/treinos"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
+              style={{ background: "var(--gradient-primary)" }}
+            >
+              <Plus className="w-4 h-4" />
+              Explorar Planos
+            </Link>
+          </div>
+        </div>
+
+        {loading && (
+          <div className="glass-card rounded-2xl p-12 flex flex-col items-center justify-center gap-3 text-muted-foreground">
+            <Loader2 className="w-8 h-8 animate-spin" />
+            <p className="text-sm">Carregando histórico...</p>
+          </div>
+        )}
+
+        {!loading && error && (
+          <div className="glass-card rounded-2xl p-6">
+            <div className="rounded-xl bg-destructive/10 border border-destructive/30 px-4 py-4 text-sm text-destructive flex items-start gap-3">
+              <AlertCircle className="w-5 h-5 shrink-0 mt-0.5" />
+              <div>
+                <p className="font-medium">Erro ao carregar histórico</p>
+                <p className="opacity-90">{error}</p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {!loading && !error && history.length === 0 && (
+          <div className="glass-card rounded-2xl p-12 flex flex-col items-center justify-center gap-4 text-muted-foreground">
+            <div className="w-16 h-16 rounded-2xl bg-secondary flex items-center justify-center">
+              <Dumbbell className="w-8 h-8" />
+            </div>
+            <div className="text-center">
+              <p className="font-medium text-foreground">
+                Nenhum plano de treino encontrado
+              </p>
+              <p className="text-sm mt-1">
+                Explore os planos disponíveis e comece sua jornada!
+              </p>
+            </div>
+            <Link
+              to="/treinos"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90 mt-2"
+              style={{ background: "var(--gradient-primary)" }}
+            >
+              <Plus className="w-4 h-4" />
+              Explorar Planos
+            </Link>
+          </div>
+        )}
+
+        {!loading && !error && history.length > 0 && (
+          <div className="space-y-8">
+            {active.length > 0 && (
+              <section className="space-y-4">
+                <h3 className="text-base font-semibold text-foreground">
+                  Ativo ({active.length})
+                </h3>
+                <div className="space-y-3">
+                  {active.map((utp) => (
+                    <HistoryCard key={utp.id} utp={utp} />
+                  ))}
+                </div>
+              </section>
+            )}
+            {past.length > 0 && (
+              <section className="space-y-4">
+                <h3 className="text-base font-semibold text-muted-foreground">
+                  Histórico ({past.length})
+                </h3>
+                <div className="space-y-3">
+                  {past.map((utp) => (
+                    <HistoryCard key={utp.id} utp={utp} />
+                  ))}
+                </div>
+              </section>
+            )}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+};
+
+// ── HistoryCard ───────────────────────────────────────────────────────────────
+
+interface HistoryCardProps {
+  utp: UserTrainingPlanDto;
+}
+
+const HistoryCard = ({ utp }: HistoryCardProps) => {
+  const plan = utp.trainingPlan;
+  const startedDate = new Date(utp.startedAt).toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+
+  const endedDate =
+    utp.completedAt
+      ? new Date(utp.completedAt).toLocaleDateString("pt-BR", {
+          day: "2-digit",
+          month: "short",
+          year: "numeric",
+        })
+      : utp.cancelledAt
+      ? new Date(utp.cancelledAt).toLocaleDateString("pt-BR", {
+          day: "2-digit",
+          month: "short",
+          year: "numeric",
+        })
+      : null;
+
+  const isActive =
+    utp.userTrainingPlanStatus === EUserTrainingPlanStatus.Active;
+
+  return (
+    <div className="glass-card rounded-xl p-5 flex flex-col sm:flex-row sm:items-center gap-4">
+      <div
+        className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
+        style={{ background: "var(--gradient-primary)" }}
+      >
+        <Dumbbell className="w-5 h-5 text-primary-foreground" />
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-start gap-2 flex-wrap">
+          <p className="font-semibold text-sm text-foreground">
+            {utp.trainingPlanName}
+          </p>
+          <span
+            className={`px-2 py-0.5 rounded-full text-xs font-medium border shrink-0 ${statusStyles[utp.userTrainingPlanStatus]}`}
+          >
+            {UserTrainingPlanStatusLabel[utp.userTrainingPlanStatus]}
+          </span>
+        </div>
+
+        {plan && (
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {TrainingObjectiveLabel[plan.objective]} ·{" "}
+            {TrainingLevelLabel[plan.level]}
+          </p>
+        )}
+
+        <div className="flex flex-wrap gap-4 mt-2">
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <CalendarDays className="w-3.5 h-3.5 shrink-0" />
+            <span>Início: {startedDate}</span>
+          </div>
+          {endedDate && (
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <CalendarDays className="w-3.5 h-3.5 shrink-0" />
+              <span>
+                {utp.userTrainingPlanStatus === EUserTrainingPlanStatus.Completed
+                  ? "Concluído"
+                  : "Cancelado"}
+                : {endedDate}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {utp.cancellationReason && (
+          <p className="text-xs text-muted-foreground mt-1 italic">
+            Motivo: {utp.cancellationReason}
+          </p>
+        )}
+      </div>
+
+      <div className="flex items-center gap-4 shrink-0">
+        <div className="text-center">
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-0.5">
+            <TrendingUp className="w-3.5 h-3.5" />
+            <span>Progresso</span>
+          </div>
+          <p className="text-lg font-bold text-primary">
+            {utp.overallProgressPercentage.toFixed(1)}%
+          </p>
+        </div>
+
+        {isActive && (
+          <Link
+            to="/treinos/meu-plano"
+            className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-primary transition-colors"
+          >
+            Ver <ChevronRight className="w-3.5 h-3.5" />
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TrainingPlanHistory;

--- a/src/frontend/src/pages/training-plans/TrainingPlansList.tsx
+++ b/src/frontend/src/pages/training-plans/TrainingPlansList.tsx
@@ -1,0 +1,254 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  Dumbbell,
+  Loader2,
+  AlertCircle,
+  RefreshCw,
+  ChevronRight,
+  Settings2,
+  Filter,
+} from "lucide-react";
+import { toast } from "sonner";
+import DashboardHeader from "@/components/DashboardHeader";
+import { getUser } from "@/lib/auth";
+import {
+  getAvailableTrainingPlans,
+  subscribeTrainingPlan,
+  TrainingPlanDto,
+  ETrainingObjective,
+  ETrainingLevel,
+  TrainingObjectiveLabel,
+  TrainingLevelLabel,
+} from "@/lib/training-plans-api";
+
+const levelColors: Record<ETrainingLevel, string> = {
+  [ETrainingLevel.Beginner]: "bg-emerald-500/10 text-emerald-400 border-emerald-500/30",
+  [ETrainingLevel.Intermediate]: "bg-primary/10 text-primary border-primary/30",
+  [ETrainingLevel.Advanced]: "bg-destructive/10 text-destructive border-destructive/30",
+};
+
+const TrainingPlansList = () => {
+  const user = getUser();
+  const isAdmin = user?.role === "Administrator";
+  const isProfessional = user?.role === "Professional";
+
+  const [plans, setPlans] = useState<TrainingPlanDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [subscribingId, setSubscribingId] = useState<string | null>(null);
+  const [objective, setObjective] = useState<ETrainingObjective | "">("");
+  const [level, setLevel] = useState<ETrainingLevel | "">("");
+
+  const load = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const res = await getAvailableTrainingPlans(
+        objective !== "" ? (objective as ETrainingObjective) : undefined,
+        level !== "" ? (level as ETrainingLevel) : undefined
+      );
+      setPlans(res.data ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erro ao carregar planos.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, [objective, level]);
+
+  const handleSubscribe = async (plan: TrainingPlanDto) => {
+    setSubscribingId(plan.id);
+    try {
+      await subscribeTrainingPlan(plan.id);
+      toast.success("Inscrição realizada!", {
+        description: `Você se inscreveu no plano "${plan.name}".`,
+      });
+      load();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Erro ao se inscrever.");
+    } finally {
+      setSubscribingId(null);
+    }
+  };
+
+  return (
+    <div className="min-h-screen px-4 md:px-[5%] py-5">
+      <DashboardHeader />
+      <main className="w-full max-w-6xl mx-auto space-y-6 animate-fade-in">
+        {/* Header */}
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+          <div>
+            <h2 className="text-2xl font-semibold">Planos de Treino</h2>
+            <p className="text-sm text-muted-foreground mt-1">
+              Encontre o plano ideal para o seu objetivo
+            </p>
+          </div>
+          <div className="flex items-center gap-3 flex-wrap">
+            <button
+              type="button"
+              onClick={load}
+              disabled={loading}
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+            >
+              <RefreshCw className={`w-4 h-4 ${loading ? "animate-spin" : ""}`} />
+              Atualizar
+            </button>
+            <Link
+              to="/treinos/meu-plano"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium border border-border text-muted-foreground hover:text-foreground hover:border-primary/50 transition-all"
+            >
+              <Dumbbell className="w-4 h-4" />
+              Meu Plano
+            </Link>
+            {(isAdmin || isProfessional) && (
+              <Link
+                to={isAdmin ? "/treinos/gestao" : "/treinos/profissional"}
+                className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
+                style={{ background: "var(--gradient-primary)" }}
+              >
+                <Settings2 className="w-4 h-4" />
+                Gerenciar
+              </Link>
+            )}
+          </div>
+        </div>
+
+        {/* Filtros */}
+        <div className="glass-card rounded-2xl p-4 flex flex-wrap gap-4 items-center">
+          <Filter className="w-4 h-4 text-muted-foreground shrink-0" />
+          <div className="flex flex-wrap gap-3 flex-1">
+            <select
+              value={objective}
+              onChange={(e) => setObjective(e.target.value === "" ? "" : Number(e.target.value) as ETrainingObjective)}
+              className="bg-secondary border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:outline-none focus:border-primary/50"
+            >
+              <option value="">Todos os objetivos</option>
+              {Object.entries(TrainingObjectiveLabel).map(([k, v]) => (
+                <option key={k} value={k}>{v}</option>
+              ))}
+            </select>
+            <select
+              value={level}
+              onChange={(e) => setLevel(e.target.value === "" ? "" : Number(e.target.value) as ETrainingLevel)}
+              className="bg-secondary border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:outline-none focus:border-primary/50"
+            >
+              <option value="">Todos os níveis</option>
+              {Object.entries(TrainingLevelLabel).map(([k, v]) => (
+                <option key={k} value={k}>{v}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Loading */}
+        {loading && (
+          <div className="glass-card rounded-2xl p-12 flex flex-col items-center justify-center gap-3 text-muted-foreground">
+            <Loader2 className="w-8 h-8 animate-spin" />
+            <p className="text-sm">Carregando planos de treino...</p>
+          </div>
+        )}
+
+        {/* Error */}
+        {!loading && error && (
+          <div className="glass-card rounded-2xl p-6">
+            <div className="rounded-xl bg-destructive/10 border border-destructive/30 px-4 py-4 text-sm text-destructive flex items-start gap-3">
+              <AlertCircle className="w-5 h-5 shrink-0 mt-0.5" />
+              <div>
+                <p className="font-medium">Erro ao carregar planos</p>
+                <p className="opacity-90">{error}</p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Empty */}
+        {!loading && !error && plans.length === 0 && (
+          <div className="glass-card rounded-2xl p-12 flex flex-col items-center justify-center gap-4 text-muted-foreground">
+            <div className="w-16 h-16 rounded-2xl bg-secondary flex items-center justify-center">
+              <Dumbbell className="w-8 h-8" />
+            </div>
+            <div className="text-center">
+              <p className="font-medium text-foreground">Nenhum plano disponível</p>
+              <p className="text-sm mt-1">Não há planos de treino ativos com os filtros selecionados.</p>
+            </div>
+          </div>
+        )}
+
+        {/* Cards */}
+        {!loading && !error && plans.length > 0 && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+            {plans.map((plan) => (
+              <PlanCard
+                key={plan.id}
+                plan={plan}
+                onSubscribe={handleSubscribe}
+                isSubscribing={subscribingId === plan.id}
+              />
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+};
+
+// ── PlanCard ──────────────────────────────────────────────────────────────────
+
+interface PlanCardProps {
+  plan: TrainingPlanDto;
+  onSubscribe: (plan: TrainingPlanDto) => void;
+  isSubscribing: boolean;
+}
+
+const PlanCard = ({ plan, onSubscribe, isSubscribing }: PlanCardProps) => (
+  <div className="glass-card rounded-xl p-5 flex flex-col gap-4 hover:-translate-y-1 hover:shadow-[0_12px_40px_-8px_hsl(282_85%_56%/0.2)] transition-all duration-300">
+    <div className="flex items-start justify-between gap-2">
+      <div
+        className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
+        style={{ background: "var(--gradient-primary)" }}
+      >
+        <Dumbbell className="w-5 h-5 text-primary-foreground" />
+      </div>
+      <span className={`px-2.5 py-1 rounded-full text-xs font-medium border shrink-0 ${levelColors[plan.level]}`}>
+        {TrainingLevelLabel[plan.level]}
+      </span>
+    </div>
+
+    <div className="flex-1">
+      <h3 className="text-sm font-semibold text-foreground leading-snug">{plan.name}</h3>
+      <p className="text-xs text-muted-foreground mt-1.5 line-clamp-3 leading-relaxed">
+        {plan.description}
+      </p>
+    </div>
+
+    <div className="space-y-1 text-xs text-muted-foreground">
+      <p>🎯 {TrainingObjectiveLabel[plan.objective]}</p>
+      <p>⏱ Duração mínima: {plan.minimumDurationDays} dias</p>
+      <p>🏋️ {plan.workouts?.length ?? 0} treino(s)</p>
+    </div>
+
+    <div className="flex gap-2 mt-auto">
+      <Link
+        to={`/treinos/${plan.id}`}
+        className="flex-1 inline-flex items-center justify-center gap-1 px-3 py-2.5 rounded-xl text-xs font-medium border border-border text-muted-foreground hover:text-foreground hover:border-primary/50 transition-all"
+      >
+        Detalhes <ChevronRight className="w-3.5 h-3.5" />
+      </Link>
+      <button
+        type="button"
+        onClick={() => onSubscribe(plan)}
+        disabled={isSubscribing}
+        className="flex-1 inline-flex items-center justify-center gap-1 px-3 py-2.5 rounded-xl text-xs font-medium text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-60"
+        style={{ background: "var(--gradient-primary)" }}
+      >
+        {isSubscribing ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : "Inscrever-se"}
+      </button>
+    </div>
+  </div>
+);
+
+export default TrainingPlansList;

--- a/src/frontend/src/pages/training-plans/management/ManagementTrainingPlanDetail.tsx
+++ b/src/frontend/src/pages/training-plans/management/ManagementTrainingPlanDetail.tsx
@@ -1,0 +1,477 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import {
+  ArrowLeft,
+  Loader2,
+  AlertCircle,
+  Dumbbell,
+  Users,
+  CheckCircle2,
+  XCircle,
+  Edit3,
+  ChevronDown,
+  ChevronUp,
+  TrendingUp,
+  CalendarDays,
+} from "lucide-react";
+import { toast } from "sonner";
+import DashboardHeader from "@/components/DashboardHeader";
+import { getUser } from "@/lib/auth";
+import {
+  adminGetTrainingPlan,
+  adminActivateTrainingPlan,
+  adminDeactivateTrainingPlan,
+  adminGetPlanSubscribers,
+  profGetManagedPlan,
+  profActivateManagedPlan,
+  profDeactivateManagedPlan,
+  profGetManagedPlanSubscribers,
+  TrainingPlanDto,
+  TrainingPlanSubscriberDto,
+  EUserTrainingPlanStatus,
+  UserTrainingPlanStatusLabel,
+  TrainingObjectiveLabel,
+  TrainingLevelLabel,
+} from "@/lib/training-plans-api";
+
+const subscriberStatusStyles: Record<EUserTrainingPlanStatus, string> = {
+  [EUserTrainingPlanStatus.Active]: "bg-emerald-500/10 text-emerald-400 border-emerald-500/30",
+  [EUserTrainingPlanStatus.Cancelled]: "bg-secondary text-muted-foreground border-border",
+  [EUserTrainingPlanStatus.Completed]: "bg-blue-500/10 text-blue-400 border-blue-500/30",
+};
+
+const ManagementTrainingPlanDetail = () => {
+  const { id } = useParams<{ id: string }>();
+  const user = getUser();
+  const isAdmin = user?.role === "Administrator";
+  const baseRoute = isAdmin ? "/treinos/gestao" : "/treinos/profissional";
+
+  const [plan, setPlan] = useState<TrainingPlanDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const [subscribers, setSubscribers] = useState<TrainingPlanSubscriberDto[]>([]);
+  const [loadingSubscribers, setLoadingSubscribers] = useState(false);
+  const [subscribersError, setSubscribersError] = useState("");
+
+  const [toggling, setToggling] = useState(false);
+
+  const [showWorkouts, setShowWorkouts] = useState(false);
+
+  const loadPlan = async () => {
+    if (!id) return;
+    setLoading(true);
+    setError("");
+    try {
+      const res = isAdmin
+        ? await adminGetTrainingPlan(id)
+        : await profGetManagedPlan(id);
+      if (res.data) {
+        setPlan(res.data);
+      } else {
+        setError("Plano não encontrado.");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erro ao carregar plano.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadSubscribers = async () => {
+    if (!id) return;
+    setLoadingSubscribers(true);
+    setSubscribersError("");
+    try {
+      const res = isAdmin
+        ? await adminGetPlanSubscribers(id)
+        : await profGetManagedPlanSubscribers(id);
+      setSubscribers(res.data ?? []);
+    } catch (err) {
+      setSubscribersError(
+        err instanceof Error ? err.message : "Erro ao carregar inscritos."
+      );
+    } finally {
+      setLoadingSubscribers(false);
+    }
+  };
+
+  useEffect(() => {
+    loadPlan();
+    loadSubscribers();
+  }, [id]);
+
+  const handleToggleStatus = async () => {
+    if (!id || !plan) return;
+    setToggling(true);
+    try {
+      const isActive = plan.status === 1;
+      const res = isActive
+        ? isAdmin
+          ? await adminDeactivateTrainingPlan(id)
+          : await profDeactivateManagedPlan(id)
+        : isAdmin
+        ? await adminActivateTrainingPlan(id)
+        : await profActivateManagedPlan(id);
+
+      setPlan(res.data!);
+      toast.success(
+        res.data!.status === 1
+          ? "Plano ativado. Agora está disponível para inscrições."
+          : "Plano desativado. Não aparecerá para novos usuários."
+      );
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Erro ao alterar status do plano."
+      );
+    } finally {
+      setToggling(false);
+    }
+  };
+
+  const isActive = plan?.status === 1;
+  const activeSubscribers = subscribers.filter(
+    (s) => s.status === EUserTrainingPlanStatus.Active
+  );
+
+  return (
+    <div className="min-h-screen px-4 md:px-[5%] py-5">
+      <DashboardHeader />
+      <main className="w-full max-w-4xl mx-auto space-y-6 animate-fade-in">
+        <Link
+          to={baseRoute}
+          className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Voltar para {isAdmin ? "Gerenciar Planos" : "Meus Planos"}
+        </Link>
+
+        {loading && (
+          <div className="glass-card rounded-2xl p-12 flex flex-col items-center justify-center gap-3 text-muted-foreground">
+            <Loader2 className="w-8 h-8 animate-spin" />
+            <p className="text-sm">Carregando plano...</p>
+          </div>
+        )}
+
+        {!loading && error && (
+          <div className="glass-card rounded-2xl p-6">
+            <div className="rounded-xl bg-destructive/10 border border-destructive/30 px-4 py-4 text-sm text-destructive flex items-start gap-3">
+              <AlertCircle className="w-5 h-5 shrink-0 mt-0.5" />
+              <p>{error}</p>
+            </div>
+          </div>
+        )}
+
+        {!loading && !error && plan && (
+          <>
+            {/* ── Dados do Plano ── */}
+            <div className="glass-card rounded-2xl p-8 space-y-6">
+              <div className="flex items-start justify-between gap-4 flex-wrap">
+                <div className="flex items-center gap-3">
+                  <div
+                    className="w-12 h-12 rounded-xl flex items-center justify-center shrink-0"
+                    style={{ background: "var(--gradient-primary)" }}
+                  >
+                    <Dumbbell className="w-6 h-6 text-primary-foreground" />
+                  </div>
+                  <div>
+                    <h2 className="text-xl font-semibold">{plan.name}</h2>
+                    <p className="text-xs font-mono text-muted-foreground mt-0.5">
+                      {plan.id}
+                    </p>
+                  </div>
+                </div>
+                <span
+                  className={`px-2.5 py-1 rounded-full text-xs font-medium border shrink-0 ${
+                    isActive
+                      ? "bg-emerald-500/10 text-emerald-400 border-emerald-500/30"
+                      : "bg-secondary text-muted-foreground border-border"
+                  }`}
+                >
+                  {isActive ? "Ativo" : "Inativo"}
+                </span>
+              </div>
+
+              <div className="h-px bg-border" />
+
+              {/* Info grid */}
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                <InfoItem
+                  icon={<Dumbbell className="w-4 h-4" />}
+                  label="Objetivo"
+                  value={TrainingObjectiveLabel[plan.objective]}
+                />
+                <InfoItem
+                  icon={<Dumbbell className="w-4 h-4" />}
+                  label="Nível"
+                  value={TrainingLevelLabel[plan.level]}
+                />
+                <InfoItem
+                  icon={<CalendarDays className="w-4 h-4" />}
+                  label="Duração Mín."
+                  value={`${plan.minimumDurationDays} dias`}
+                />
+                <InfoItem
+                  icon={<Users className="w-4 h-4" />}
+                  label="Inscritos"
+                  value={`${plan.activeSubscriberCount} ativo${plan.activeSubscriberCount !== 1 ? "s" : ""} / ${plan.subscriberCount} total`}
+                />
+              </div>
+
+              {/* Descrição */}
+              <div className="rounded-xl border border-border bg-secondary/40 px-4 py-3">
+                <p className="text-xs text-muted-foreground font-medium uppercase tracking-wide mb-2">
+                  Descrição
+                </p>
+                <p className="text-sm text-foreground whitespace-pre-wrap leading-relaxed">
+                  {plan.description}
+                </p>
+              </div>
+
+              {plan.instructions && (
+                <div className="rounded-xl border border-border bg-secondary/40 px-4 py-3">
+                  <p className="text-xs text-muted-foreground font-medium uppercase tracking-wide mb-2">
+                    Instruções
+                  </p>
+                  <p className="text-sm text-foreground leading-relaxed">
+                    {plan.instructions}
+                  </p>
+                </div>
+              )}
+
+              {/* Actions */}
+              <div className="flex items-center gap-3 flex-wrap">
+                <Link
+                  to={`${baseRoute}/${plan.id}/editar`}
+                  className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
+                  style={{ background: "var(--gradient-primary)" }}
+                >
+                  <Edit3 className="w-4 h-4" />
+                  Editar Plano
+                </Link>
+                <button
+                  type="button"
+                  onClick={handleToggleStatus}
+                  disabled={toggling}
+                  className={`inline-flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium border transition-colors disabled:opacity-60 ${
+                    isActive
+                      ? "text-destructive border-destructive/30 hover:bg-destructive/10"
+                      : "text-emerald-400 border-emerald-500/30 hover:bg-emerald-500/10"
+                  }`}
+                >
+                  {toggling ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  ) : isActive ? (
+                    <XCircle className="w-4 h-4" />
+                  ) : (
+                    <CheckCircle2 className="w-4 h-4" />
+                  )}
+                  {isActive ? "Desativar Plano" : "Ativar Plano"}
+                </button>
+              </div>
+            </div>
+
+            {/* ── Treinos ── */}
+            {plan.workouts && plan.workouts.length > 0 && (
+              <div className="glass-card rounded-2xl overflow-hidden">
+                <button
+                  type="button"
+                  onClick={() => setShowWorkouts((v) => !v)}
+                  className="w-full flex items-center justify-between px-6 py-4 hover:bg-secondary/30 transition-colors"
+                >
+                  <div className="flex items-center gap-2">
+                    <Dumbbell className="w-4 h-4 text-muted-foreground" />
+                    <span className="text-sm font-semibold">
+                      Treinos ({plan.workouts.length})
+                    </span>
+                  </div>
+                  {showWorkouts ? (
+                    <ChevronUp className="w-4 h-4 text-muted-foreground" />
+                  ) : (
+                    <ChevronDown className="w-4 h-4 text-muted-foreground" />
+                  )}
+                </button>
+
+                {showWorkouts && (
+                  <div className="px-6 pb-6 space-y-4 border-t border-border pt-4">
+                    {plan.workouts
+                      .sort((a, b) => a.order - b.order)
+                      .map((workout) => (
+                        <div
+                          key={workout.id}
+                          className="rounded-xl border border-border bg-secondary/30 p-4 space-y-3"
+                        >
+                          <div>
+                            <p className="text-sm font-medium">
+                              {workout.order}. {workout.name}
+                            </p>
+                            {workout.description && (
+                              <p className="text-xs text-muted-foreground mt-0.5">
+                                {workout.description}
+                              </p>
+                            )}
+                          </div>
+                          {workout.items && workout.items.length > 0 && (
+                            <div className="space-y-1.5 pt-2 border-t border-border/60">
+                              {workout.items
+                                .filter((i) => i.status === 1)
+                                .sort((a, b) => a.order - b.order)
+                                .map((item) => (
+                                  <div
+                                    key={item.id}
+                                    className="flex items-start gap-2 text-xs text-muted-foreground"
+                                  >
+                                    <CheckCircle2 className="w-3.5 h-3.5 text-primary/50 mt-0.5 shrink-0" />
+                                    <div>
+                                      <span className="text-foreground font-medium">
+                                        {item.name}
+                                      </span>
+                                      {(item.sets || item.repetitions) && (
+                                        <span className="ml-2 text-primary">
+                                          {item.sets && `${item.sets} séries`}
+                                          {item.sets && item.repetitions && " × "}
+                                          {item.repetitions && `${item.repetitions} reps`}
+                                        </span>
+                                      )}
+                                    </div>
+                                  </div>
+                                ))}
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* ── Inscritos ── */}
+            <div className="glass-card rounded-2xl p-8 space-y-5">
+              <div className="flex items-center gap-2">
+                <Users className="w-5 h-5 text-muted-foreground" />
+                <h3 className="text-lg font-semibold">
+                  Inscritos ({subscribers.length})
+                </h3>
+                {activeSubscribers.length > 0 && (
+                  <span className="px-2 py-0.5 rounded-full text-xs bg-emerald-500/10 text-emerald-400 border border-emerald-500/30">
+                    {activeSubscribers.length} ativo{activeSubscribers.length !== 1 ? "s" : ""}
+                  </span>
+                )}
+              </div>
+
+              {loadingSubscribers && (
+                <div className="flex items-center gap-3 text-muted-foreground py-6 justify-center">
+                  <Loader2 className="w-5 h-5 animate-spin" />
+                  <span className="text-sm">Carregando inscritos...</span>
+                </div>
+              )}
+
+              {!loadingSubscribers && subscribersError && (
+                <div className="rounded-xl bg-destructive/10 border border-destructive/30 px-4 py-3 text-sm text-destructive flex items-center gap-2">
+                  <AlertCircle className="w-4 h-4 shrink-0" />
+                  {subscribersError}
+                </div>
+              )}
+
+              {!loadingSubscribers && !subscribersError && subscribers.length === 0 && (
+                <div className="rounded-xl bg-secondary/40 py-8 flex flex-col items-center gap-2 text-muted-foreground">
+                  <Users className="w-6 h-6" />
+                  <p className="text-sm">Nenhum inscrito ainda.</p>
+                </div>
+              )}
+
+              {!loadingSubscribers && !subscribersError && subscribers.length > 0 && (
+                <div className="rounded-xl border border-border overflow-hidden">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-border bg-secondary/30">
+                        <th className="text-left px-4 py-3 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                          Usuário
+                        </th>
+                        <th className="text-left px-4 py-3 text-xs font-semibold text-muted-foreground uppercase tracking-wide hidden sm:table-cell">
+                          Status
+                        </th>
+                        <th className="text-left px-4 py-3 text-xs font-semibold text-muted-foreground uppercase tracking-wide hidden md:table-cell">
+                          Progresso
+                        </th>
+                        <th className="text-left px-4 py-3 text-xs font-semibold text-muted-foreground uppercase tracking-wide hidden lg:table-cell">
+                          Início
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-border">
+                      {subscribers.map((s) => (
+                        <SubscriberRow key={s.userTrainingPlanId} subscriber={s} />
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </main>
+    </div>
+  );
+};
+
+// ── Sub-components ─────────────────────────────────────────────────────────────
+
+const InfoItem = ({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+}) => (
+  <div>
+    <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
+      {icon}
+      <span className="font-medium uppercase tracking-wide">{label}</span>
+    </div>
+    <p className="text-sm text-foreground font-medium">{value}</p>
+  </div>
+);
+
+const SubscriberRow = ({
+  subscriber: s,
+}: {
+  subscriber: TrainingPlanSubscriberDto;
+}) => (
+  <tr className="hover:bg-secondary/20 transition-colors">
+    <td className="px-4 py-3">
+      <p className="text-sm font-medium text-foreground">{s.userFullName || "—"}</p>
+    </td>
+    <td className="px-4 py-3 hidden sm:table-cell">
+      <span
+        className={`px-2 py-0.5 rounded-full text-xs font-medium border ${subscriberStatusStyles[s.status]}`}
+      >
+        {UserTrainingPlanStatusLabel[s.status]}
+      </span>
+    </td>
+    <td className="px-4 py-3 hidden md:table-cell">
+      <div className="flex items-center gap-1.5">
+        <TrendingUp className="w-3.5 h-3.5 text-muted-foreground" />
+        <span className="text-xs text-primary font-medium">
+          {s.overallProgressPercentage.toFixed(1)}%
+        </span>
+      </div>
+    </td>
+    <td className="px-4 py-3 hidden lg:table-cell">
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <CalendarDays className="w-3.5 h-3.5" />
+        <span>
+          {new Date(s.startedAt).toLocaleDateString("pt-BR", {
+            day: "2-digit",
+            month: "short",
+            year: "numeric",
+          })}
+        </span>
+      </div>
+    </td>
+  </tr>
+);
+
+export default ManagementTrainingPlanDetail;

--- a/src/frontend/src/pages/training-plans/management/ManagementTrainingPlanForm.tsx
+++ b/src/frontend/src/pages/training-plans/management/ManagementTrainingPlanForm.tsx
@@ -1,0 +1,764 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import {
+  ArrowLeft,
+  Loader2,
+  AlertCircle,
+  Plus,
+  Trash2,
+  ChevronDown,
+  ChevronUp,
+  GripVertical,
+} from "lucide-react";
+import { toast } from "sonner";
+import DashboardHeader from "@/components/DashboardHeader";
+import { getUser } from "@/lib/auth";
+import {
+  adminGetTrainingPlan,
+  adminCreateTrainingPlan,
+  adminUpdateTrainingPlan,
+  profGetManagedPlan,
+  profCreateManagedPlan,
+  profUpdateManagedPlan,
+  ETrainingObjective,
+  ETrainingLevel,
+  TrainingObjectiveLabel,
+  TrainingLevelLabel,
+  TrainingPlanDto,
+} from "@/lib/training-plans-api";
+
+// ── Form types ─────────────────────────────────────────────────────────────────
+
+interface ItemForm {
+  id?: string;
+  name: string;
+  description: string;
+  instructions: string;
+  sets: string;
+  repetitions: string;
+  order: number;
+}
+
+interface WorkoutForm {
+  id?: string;
+  name: string;
+  description: string;
+  instructions: string;
+  order: number;
+  items: ItemForm[];
+  collapsed: boolean;
+}
+
+const emptyItem = (order: number): ItemForm => ({
+  name: "",
+  description: "",
+  instructions: "",
+  sets: "",
+  repetitions: "",
+  order,
+});
+
+const emptyWorkout = (order: number): WorkoutForm => ({
+  name: "",
+  description: "",
+  instructions: "",
+  order,
+  items: [emptyItem(1)],
+  collapsed: false,
+});
+
+// ── Component ──────────────────────────────────────────────────────────────────
+
+const ManagementTrainingPlanForm = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const user = getUser();
+  const isAdmin = user?.role === "Administrator";
+  const isEdit = Boolean(id);
+  const baseRoute = isAdmin ? "/treinos/gestao" : "/treinos/profissional";
+
+  // Plan fields
+  const [planName, setPlanName] = useState("");
+  const [planDescription, setPlanDescription] = useState("");
+  const [planObjective, setPlanObjective] = useState<ETrainingObjective | "">("");
+  const [planLevel, setPlanLevel] = useState<ETrainingLevel | "">("");
+  const [planInstructions, setPlanInstructions] = useState("");
+  const [planMinDays, setPlanMinDays] = useState("30");
+  const [workouts, setWorkouts] = useState<WorkoutForm[]>([emptyWorkout(1)]);
+
+  const [loading, setLoading] = useState(isEdit);
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState<string[]>([]);
+
+  // ── Load existing plan for editing ──────────────────────────────────────────
+
+  useEffect(() => {
+    if (!isEdit || !id) return;
+
+    const loadPlan = async () => {
+      setLoading(true);
+      try {
+        const res = isAdmin
+          ? await adminGetTrainingPlan(id)
+          : await profGetManagedPlan(id);
+
+        if (!res.data) {
+          setErrors(["Plano não encontrado."]);
+          return;
+        }
+        populateForm(res.data);
+      } catch (err) {
+        setErrors([err instanceof Error ? err.message : "Erro ao carregar plano."]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadPlan();
+  }, [id]);
+
+  const populateForm = (plan: TrainingPlanDto) => {
+    setPlanName(plan.name);
+    setPlanDescription(plan.description);
+    setPlanObjective(plan.objective);
+    setPlanLevel(plan.level);
+    setPlanInstructions(plan.instructions ?? "");
+    setPlanMinDays(String(plan.minimumDurationDays));
+    setWorkouts(
+      (plan.workouts ?? [])
+        .sort((a, b) => a.order - b.order)
+        .map((w) => ({
+          id: w.id,
+          name: w.name,
+          description: w.description ?? "",
+          instructions: w.instructions ?? "",
+          order: w.order,
+          collapsed: false,
+          items: (w.items ?? [])
+            .filter((i) => i.status === 1)
+            .sort((a, b) => a.order - b.order)
+            .map((i) => ({
+              id: i.id,
+              name: i.name,
+              description: i.description ?? "",
+              instructions: i.instructions ?? "",
+              sets: i.sets != null ? String(i.sets) : "",
+              repetitions: i.repetitions != null ? String(i.repetitions) : "",
+              order: i.order,
+            })),
+        }))
+    );
+  };
+
+  // ── Validation ───────────────────────────────────────────────────────────────
+
+  const validate = (): string[] => {
+    const errs: string[] = [];
+    if (!planName.trim()) errs.push("O nome do plano é obrigatório.");
+    else if (planName.trim().length < 3) errs.push("O nome deve ter no mínimo 3 caracteres.");
+    else if (planName.trim().length > 150) errs.push("O nome deve ter no máximo 150 caracteres.");
+
+    if (!planDescription.trim()) errs.push("A descrição é obrigatória.");
+    else if (planDescription.trim().length > 4000) errs.push("A descrição deve ter no máximo 4000 caracteres.");
+
+    if (planObjective === "") errs.push("O objetivo é obrigatório.");
+    if (planLevel === "") errs.push("O nível é obrigatório.");
+
+    const minDaysNum = parseInt(planMinDays, 10);
+    if (isNaN(minDaysNum) || minDaysNum < 1) errs.push("A duração mínima deve ser de pelo menos 1 dia.");
+
+    if (workouts.length === 0) errs.push("O plano deve ter pelo menos 1 treino.");
+
+    workouts.forEach((w, wi) => {
+      if (!w.name.trim()) errs.push(`Treino ${wi + 1}: o nome é obrigatório.`);
+      if (w.items.length === 0) errs.push(`Treino ${wi + 1} deve ter pelo menos 1 exercício.`);
+      w.items.forEach((item, ii) => {
+        if (!item.name.trim()) errs.push(`Treino ${wi + 1}, exercício ${ii + 1}: o nome é obrigatório.`);
+      });
+    });
+
+    return errs;
+  };
+
+  // ── Submit ───────────────────────────────────────────────────────────────────
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const clientErrors = validate();
+    if (clientErrors.length > 0) {
+      setErrors(clientErrors);
+      window.scrollTo({ top: 0, behavior: "smooth" });
+      return;
+    }
+
+    setErrors([]);
+    setSaving(true);
+
+    const workoutsPayload = workouts.map((w, wi) => ({
+      ...(isEdit && w.id ? { id: w.id } : {}),
+      name: w.name.trim(),
+      description: w.description.trim() || undefined,
+      instructions: w.instructions.trim() || undefined,
+      order: wi + 1,
+      items: w.items.map((item, ii) => ({
+        ...(isEdit && item.id ? { id: item.id } : {}),
+        name: item.name.trim(),
+        description: item.description.trim() || undefined,
+        instructions: item.instructions.trim() || undefined,
+        sets: item.sets !== "" ? parseInt(item.sets, 10) : undefined,
+        repetitions: item.repetitions !== "" ? parseInt(item.repetitions, 10) : undefined,
+        order: ii + 1,
+      })),
+    }));
+
+    const planPayload = {
+      name: planName.trim(),
+      description: planDescription.trim(),
+      objective: planObjective as ETrainingObjective,
+      level: planLevel as ETrainingLevel,
+      instructions: planInstructions.trim() || undefined,
+      minimumDurationDays: parseInt(planMinDays, 10),
+      workouts: workoutsPayload,
+    };
+
+    try {
+      let res;
+      if (isEdit && id) {
+        res = isAdmin
+          ? await adminUpdateTrainingPlan(id, planPayload)
+          : await profUpdateManagedPlan(id, planPayload);
+        toast.success("Plano atualizado com sucesso!");
+      } else {
+        res = isAdmin
+          ? await adminCreateTrainingPlan(planPayload)
+          : await profCreateManagedPlan(planPayload);
+        toast.success("Plano criado com sucesso!", {
+          description: `"${planName.trim()}" está pronto. Ative-o para disponibilizar aos usuários.`,
+        });
+      }
+
+      navigate(`${baseRoute}/${res.data!.id}`);
+    } catch (err) {
+      setErrors([err instanceof Error ? err.message : "Erro ao salvar plano."]);
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // ── Workout helpers ──────────────────────────────────────────────────────────
+
+  const addWorkout = () => {
+    setWorkouts((prev) => [...prev, emptyWorkout(prev.length + 1)]);
+  };
+
+  const removeWorkout = (wi: number) => {
+    setWorkouts((prev) => prev.filter((_, i) => i !== wi));
+  };
+
+  const updateWorkout = (wi: number, patch: Partial<WorkoutForm>) => {
+    setWorkouts((prev) =>
+      prev.map((w, i) => (i === wi ? { ...w, ...patch } : w))
+    );
+  };
+
+  const addItem = (wi: number) => {
+    setWorkouts((prev) =>
+      prev.map((w, i) =>
+        i === wi
+          ? { ...w, items: [...w.items, emptyItem(w.items.length + 1)] }
+          : w
+      )
+    );
+  };
+
+  const removeItem = (wi: number, ii: number) => {
+    setWorkouts((prev) =>
+      prev.map((w, i) =>
+        i === wi ? { ...w, items: w.items.filter((_, j) => j !== ii) } : w
+      )
+    );
+  };
+
+  const updateItem = (wi: number, ii: number, patch: Partial<ItemForm>) => {
+    setWorkouts((prev) =>
+      prev.map((w, i) =>
+        i === wi
+          ? {
+              ...w,
+              items: w.items.map((item, j) =>
+                j === ii ? { ...item, ...patch } : item
+              ),
+            }
+          : w
+      )
+    );
+  };
+
+  // ── Render ───────────────────────────────────────────────────────────────────
+
+  if (loading) {
+    return (
+      <div className="min-h-screen px-4 md:px-[5%] py-5">
+        <DashboardHeader />
+        <div className="flex items-center justify-center min-h-[60vh]">
+          <Loader2 className="w-8 h-8 animate-spin text-primary" />
+        </div>
+      </div>
+    );
+  }
+
+  const inputCls =
+    "w-full rounded-xl border border-border bg-secondary/40 px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary/60 transition-all disabled:opacity-60";
+
+  return (
+    <div className="min-h-screen px-4 md:px-[5%] py-5">
+      <DashboardHeader />
+      <main className="w-full max-w-3xl mx-auto space-y-6 animate-fade-in">
+        <Link
+          to={baseRoute}
+          className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Voltar para {isAdmin ? "Gerenciar Planos" : "Meus Planos"}
+        </Link>
+
+        <div className="glass-card rounded-2xl p-8 space-y-6">
+          <div>
+            <h2 className="text-xl font-semibold">
+              {isEdit ? "Editar Plano de Treino" : "Criar Plano de Treino"}
+            </h2>
+            <p className="text-sm text-muted-foreground mt-1">
+              {isEdit
+                ? "Atualize os dados do plano. Os treinos existentes podem ser editados ou removidos."
+                : "Preencha os dados do plano e adicione os treinos com seus exercícios."}
+            </p>
+          </div>
+
+          <div className="h-px bg-border" />
+
+          {errors.length > 0 && (
+            <div className="rounded-xl bg-destructive/10 border border-destructive/30 px-4 py-4 space-y-1">
+              <div className="flex items-center gap-2 text-destructive mb-2">
+                <AlertCircle className="w-4 h-4 shrink-0" />
+                <span className="text-sm font-medium">Corrija os erros abaixo:</span>
+              </div>
+              {errors.map((err, i) => (
+                <p key={i} className="text-sm text-destructive pl-6">• {err}</p>
+              ))}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit} className="space-y-8">
+            {/* ── Dados do Plano ── */}
+            <section className="space-y-4">
+              <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+                Dados do Plano
+              </h3>
+
+              {/* Nome */}
+              <div>
+                <label className="block text-xs text-muted-foreground mb-1.5 font-medium">
+                  Nome <span className="text-destructive">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={planName}
+                  onChange={(e) => setPlanName(e.target.value)}
+                  placeholder="Ex: Treino de Força para Iniciantes"
+                  maxLength={150}
+                  disabled={saving}
+                  className={inputCls}
+                />
+                <div className="flex justify-between mt-1">
+                  <span className="text-xs text-muted-foreground">Mínimo 3 caracteres</span>
+                  <span className="text-xs text-muted-foreground">{planName.length}/150</span>
+                </div>
+              </div>
+
+              {/* Objetivo + Nível */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-xs text-muted-foreground mb-1.5 font-medium">
+                    Objetivo <span className="text-destructive">*</span>
+                  </label>
+                  <select
+                    value={planObjective}
+                    onChange={(e) =>
+                      setPlanObjective(
+                        e.target.value === "" ? "" : (Number(e.target.value) as ETrainingObjective)
+                      )
+                    }
+                    disabled={saving}
+                    className={inputCls}
+                  >
+                    <option value="" disabled>
+                      Selecione o objetivo
+                    </option>
+                    {Object.entries(TrainingObjectiveLabel).map(([k, v]) => (
+                      <option key={k} value={k}>{v}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-xs text-muted-foreground mb-1.5 font-medium">
+                    Nível <span className="text-destructive">*</span>
+                  </label>
+                  <select
+                    value={planLevel}
+                    onChange={(e) =>
+                      setPlanLevel(
+                        e.target.value === "" ? "" : (Number(e.target.value) as ETrainingLevel)
+                      )
+                    }
+                    disabled={saving}
+                    className={inputCls}
+                  >
+                    <option value="" disabled>
+                      Selecione o nível
+                    </option>
+                    {Object.entries(TrainingLevelLabel).map(([k, v]) => (
+                      <option key={k} value={k}>{v}</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
+              {/* Duração mínima */}
+              <div>
+                <label className="block text-xs text-muted-foreground mb-1.5 font-medium">
+                  Duração Mínima (dias) <span className="text-destructive">*</span>
+                </label>
+                <input
+                  type="number"
+                  value={planMinDays}
+                  onChange={(e) => setPlanMinDays(e.target.value)}
+                  min={1}
+                  max={365}
+                  disabled={saving}
+                  className={inputCls}
+                />
+                <p className="text-xs text-muted-foreground mt-1">
+                  Número mínimo de dias de progresso para considerar o plano concluído.
+                </p>
+              </div>
+
+              {/* Descrição */}
+              <div>
+                <label className="block text-xs text-muted-foreground mb-1.5 font-medium">
+                  Descrição <span className="text-destructive">*</span>
+                </label>
+                <textarea
+                  value={planDescription}
+                  onChange={(e) => setPlanDescription(e.target.value)}
+                  placeholder="Descreva o plano: objetivos, público-alvo, benefícios esperados..."
+                  rows={4}
+                  maxLength={4000}
+                  disabled={saving}
+                  className={`${inputCls} resize-none`}
+                />
+                <div className="flex justify-end mt-1">
+                  <span className="text-xs text-muted-foreground">{planDescription.length}/4000</span>
+                </div>
+              </div>
+
+              {/* Instruções */}
+              <div>
+                <label className="block text-xs text-muted-foreground mb-1.5 font-medium">
+                  Instruções Gerais
+                </label>
+                <textarea
+                  value={planInstructions}
+                  onChange={(e) => setPlanInstructions(e.target.value)}
+                  placeholder="Orientações gerais, dicas de aquecimento, frequência semanal recomendada..."
+                  rows={3}
+                  disabled={saving}
+                  className={`${inputCls} resize-none`}
+                />
+              </div>
+            </section>
+
+            <div className="h-px bg-border" />
+
+            {/* ── Treinos ── */}
+            <section className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+                  Treinos ({workouts.length})
+                </h3>
+                <button
+                  type="button"
+                  onClick={addWorkout}
+                  disabled={saving}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-primary border border-primary/30 hover:bg-primary/10 transition-colors disabled:opacity-50"
+                >
+                  <Plus className="w-3.5 h-3.5" />
+                  Adicionar Treino
+                </button>
+              </div>
+
+              {workouts.map((workout, wi) => (
+                <WorkoutBlock
+                  key={wi}
+                  workout={workout}
+                  workoutIndex={wi}
+                  saving={saving}
+                  onUpdate={(patch) => updateWorkout(wi, patch)}
+                  onRemove={() => removeWorkout(wi)}
+                  onAddItem={() => addItem(wi)}
+                  onRemoveItem={(ii) => removeItem(wi, ii)}
+                  onUpdateItem={(ii, patch) => updateItem(wi, ii, patch)}
+                  inputCls={inputCls}
+                />
+              ))}
+
+              {workouts.length === 0 && (
+                <div className="rounded-xl border border-dashed border-border p-8 flex flex-col items-center gap-3 text-muted-foreground">
+                  <GripVertical className="w-6 h-6" />
+                  <p className="text-sm">Nenhum treino adicionado. Clique em "Adicionar Treino" para começar.</p>
+                </div>
+              )}
+            </section>
+
+            <div className="h-px bg-border" />
+
+            {/* Actions */}
+            <div className="flex items-center gap-3">
+              <button
+                type="submit"
+                disabled={saving}
+                className="inline-flex items-center gap-2 px-6 py-3 rounded-xl text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+                style={{ background: "var(--gradient-primary)" }}
+              >
+                {saving ? (
+                  <><Loader2 className="w-4 h-4 animate-spin" /> Salvando...</>
+                ) : isEdit ? (
+                  "Salvar Alterações"
+                ) : (
+                  "Criar Plano"
+                )}
+              </button>
+              <Link
+                to={isEdit && id ? `${baseRoute}/${id}` : baseRoute}
+                className="px-4 py-3 rounded-xl text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+              >
+                Cancelar
+              </Link>
+            </div>
+          </form>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+// ── WorkoutBlock ───────────────────────────────────────────────────────────────
+
+interface WorkoutBlockProps {
+  workout: WorkoutForm;
+  workoutIndex: number;
+  saving: boolean;
+  onUpdate: (patch: Partial<WorkoutForm>) => void;
+  onRemove: () => void;
+  onAddItem: () => void;
+  onRemoveItem: (ii: number) => void;
+  onUpdateItem: (ii: number, patch: Partial<ItemForm>) => void;
+  inputCls: string;
+}
+
+const WorkoutBlock = ({
+  workout,
+  workoutIndex,
+  saving,
+  onUpdate,
+  onRemove,
+  onAddItem,
+  onRemoveItem,
+  onUpdateItem,
+  inputCls,
+}: WorkoutBlockProps) => (
+  <div className="rounded-xl border border-border bg-secondary/20 overflow-hidden">
+    {/* Workout header */}
+    <div className="flex items-center gap-3 px-4 py-3 border-b border-border bg-secondary/40">
+      <GripVertical className="w-4 h-4 text-muted-foreground shrink-0" />
+      <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide flex-1">
+        Treino {workoutIndex + 1}
+        {workout.name && ` — ${workout.name}`}
+      </span>
+      <button
+        type="button"
+        onClick={() => onUpdate({ collapsed: !workout.collapsed })}
+        className="text-muted-foreground hover:text-foreground transition-colors p-1"
+      >
+        {workout.collapsed ? (
+          <ChevronDown className="w-4 h-4" />
+        ) : (
+          <ChevronUp className="w-4 h-4" />
+        )}
+      </button>
+      <button
+        type="button"
+        onClick={onRemove}
+        disabled={saving}
+        className="text-destructive/70 hover:text-destructive transition-colors p-1 disabled:opacity-50"
+      >
+        <Trash2 className="w-4 h-4" />
+      </button>
+    </div>
+
+    {!workout.collapsed && (
+      <div className="p-4 space-y-4">
+        {/* Workout fields */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div className="sm:col-span-2">
+            <label className="block text-xs text-muted-foreground mb-1 font-medium">
+              Nome <span className="text-destructive">*</span>
+            </label>
+            <input
+              type="text"
+              value={workout.name}
+              onChange={(e) => onUpdate({ name: e.target.value })}
+              placeholder="Ex: Peito e Tríceps"
+              maxLength={100}
+              disabled={saving}
+              className={inputCls}
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-muted-foreground mb-1 font-medium">
+              Descrição
+            </label>
+            <input
+              type="text"
+              value={workout.description}
+              onChange={(e) => onUpdate({ description: e.target.value })}
+              placeholder="Breve descrição do treino"
+              maxLength={500}
+              disabled={saving}
+              className={inputCls}
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-muted-foreground mb-1 font-medium">
+              Instruções
+            </label>
+            <input
+              type="text"
+              value={workout.instructions}
+              onChange={(e) => onUpdate({ instructions: e.target.value })}
+              placeholder="Ex: Descanso de 60s entre séries"
+              maxLength={500}
+              disabled={saving}
+              className={inputCls}
+            />
+          </div>
+        </div>
+
+        {/* Items */}
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+              Exercícios ({workout.items.length})
+            </p>
+            <button
+              type="button"
+              onClick={onAddItem}
+              disabled={saving}
+              className="inline-flex items-center gap-1 text-xs text-primary hover:text-primary/80 transition-colors disabled:opacity-50"
+            >
+              <Plus className="w-3.5 h-3.5" />
+              Adicionar Exercício
+            </button>
+          </div>
+
+          {workout.items.map((item, ii) => (
+            <ItemRow
+              key={ii}
+              item={item}
+              itemIndex={ii}
+              saving={saving}
+              onUpdate={(patch) => onUpdateItem(ii, patch)}
+              onRemove={() => onRemoveItem(ii)}
+              inputCls={inputCls}
+            />
+          ))}
+
+          {workout.items.length === 0 && (
+            <p className="text-xs text-muted-foreground italic px-1">
+              Nenhum exercício. Clique em "Adicionar Exercício".
+            </p>
+          )}
+        </div>
+      </div>
+    )}
+  </div>
+);
+
+// ── ItemRow ────────────────────────────────────────────────────────────────────
+
+interface ItemRowProps {
+  item: ItemForm;
+  itemIndex: number;
+  saving: boolean;
+  onUpdate: (patch: Partial<ItemForm>) => void;
+  onRemove: () => void;
+  inputCls: string;
+}
+
+const ItemRow = ({ item, itemIndex, saving, onUpdate, onRemove, inputCls }: ItemRowProps) => (
+  <div className="rounded-lg border border-border/60 bg-background/30 p-3 space-y-3">
+    <div className="flex items-center gap-2">
+      <span className="text-xs text-muted-foreground font-medium shrink-0 w-5 text-right">
+        {itemIndex + 1}.
+      </span>
+      <input
+        type="text"
+        value={item.name}
+        onChange={(e) => onUpdate({ name: e.target.value })}
+        placeholder="Nome do exercício *"
+        maxLength={100}
+        disabled={saving}
+        className={`${inputCls} flex-1`}
+      />
+      <button
+        type="button"
+        onClick={onRemove}
+        disabled={saving}
+        className="text-destructive/70 hover:text-destructive transition-colors p-1 shrink-0 disabled:opacity-50"
+      >
+        <Trash2 className="w-3.5 h-3.5" />
+      </button>
+    </div>
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 pl-7">
+      <input
+        type="number"
+        value={item.sets}
+        onChange={(e) => onUpdate({ sets: e.target.value })}
+        placeholder="Séries"
+        min={1}
+        disabled={saving}
+        className={inputCls}
+      />
+      <input
+        type="number"
+        value={item.repetitions}
+        onChange={(e) => onUpdate({ repetitions: e.target.value })}
+        placeholder="Reps"
+        min={1}
+        disabled={saving}
+        className={inputCls}
+      />
+      <input
+        type="text"
+        value={item.instructions}
+        onChange={(e) => onUpdate({ instructions: e.target.value })}
+        placeholder="Instruções"
+        maxLength={300}
+        disabled={saving}
+        className={`${inputCls} sm:col-span-2`}
+      />
+    </div>
+  </div>
+);
+
+export default ManagementTrainingPlanForm;

--- a/src/frontend/src/pages/training-plans/management/ManagementTrainingPlansList.tsx
+++ b/src/frontend/src/pages/training-plans/management/ManagementTrainingPlansList.tsx
@@ -1,0 +1,242 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  Dumbbell,
+  Loader2,
+  AlertCircle,
+  RefreshCw,
+  Plus,
+  Users,
+  ChevronRight,
+} from "lucide-react";
+import DashboardHeader from "@/components/DashboardHeader";
+import { getUser } from "@/lib/auth";
+import {
+  adminGetAllTrainingPlans,
+  profGetManagedPlans,
+  TrainingPlanDto,
+  ETrainingLevel,
+  TrainingObjectiveLabel,
+  TrainingLevelLabel,
+} from "@/lib/training-plans-api";
+
+const levelColors: Record<ETrainingLevel, string> = {
+  [ETrainingLevel.Beginner]: "bg-emerald-500/10 text-emerald-400 border-emerald-500/30",
+  [ETrainingLevel.Intermediate]: "bg-primary/10 text-primary border-primary/30",
+  [ETrainingLevel.Advanced]: "bg-destructive/10 text-destructive border-destructive/30",
+};
+
+const ManagementTrainingPlansList = () => {
+  const user = getUser();
+  const isAdmin = user?.role === "Administrator";
+  const baseRoute = isAdmin ? "/treinos/gestao" : "/treinos/profissional";
+
+  const [plans, setPlans] = useState<TrainingPlanDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const load = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const res = isAdmin
+        ? await adminGetAllTrainingPlans()
+        : await profGetManagedPlans();
+      setPlans(res.data ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erro ao carregar planos.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  return (
+    <div className="min-h-screen px-4 md:px-[5%] py-5">
+      <DashboardHeader />
+      <main className="w-full max-w-6xl mx-auto space-y-6 animate-fade-in">
+        {/* Header */}
+        <div className="flex items-center justify-between flex-wrap gap-3">
+          <div>
+            <h2 className="text-2xl font-semibold">
+              {isAdmin ? "Gerenciar Planos de Treino" : "Meus Planos de Treino"}
+            </h2>
+            <p className="text-sm text-muted-foreground mt-1">
+              {isAdmin
+                ? "Administração completa dos planos da plataforma"
+                : "Planos que você criou e gerencia"}
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={load}
+              disabled={loading}
+              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+            >
+              <RefreshCw className={`w-4 h-4 ${loading ? "animate-spin" : ""}`} />
+              Atualizar
+            </button>
+            <Link
+              to={`${baseRoute}/criar`}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
+              style={{ background: "var(--gradient-primary)" }}
+            >
+              <Plus className="w-4 h-4" />
+              Criar Plano
+            </Link>
+          </div>
+        </div>
+
+        {loading && (
+          <div className="glass-card rounded-2xl p-12 flex flex-col items-center justify-center gap-3 text-muted-foreground">
+            <Loader2 className="w-8 h-8 animate-spin" />
+            <p className="text-sm">Carregando planos...</p>
+          </div>
+        )}
+
+        {!loading && error && (
+          <div className="glass-card rounded-2xl p-6">
+            <div className="rounded-xl bg-destructive/10 border border-destructive/30 px-4 py-4 text-sm text-destructive flex items-start gap-3">
+              <AlertCircle className="w-5 h-5 shrink-0 mt-0.5" />
+              <div>
+                <p className="font-medium">Erro ao carregar planos</p>
+                <p className="opacity-90">{error}</p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {!loading && !error && plans.length === 0 && (
+          <div className="glass-card rounded-2xl p-12 flex flex-col items-center justify-center gap-4 text-muted-foreground">
+            <div className="w-16 h-16 rounded-2xl bg-secondary flex items-center justify-center">
+              <Dumbbell className="w-8 h-8" />
+            </div>
+            <div className="text-center">
+              <p className="font-medium text-foreground">Nenhum plano cadastrado</p>
+              <p className="text-sm mt-1">
+                Crie o primeiro plano de treino para os usuários da plataforma.
+              </p>
+            </div>
+            <Link
+              to={`${baseRoute}/criar`}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90 mt-2"
+              style={{ background: "var(--gradient-primary)" }}
+            >
+              <Plus className="w-4 h-4" />
+              Criar Primeiro Plano
+            </Link>
+          </div>
+        )}
+
+        {!loading && !error && plans.length > 0 && (
+          <div className="glass-card rounded-2xl overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="text-left px-6 py-4 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                    Plano
+                  </th>
+                  <th className="text-left px-4 py-4 text-xs font-semibold text-muted-foreground uppercase tracking-wide hidden md:table-cell">
+                    Nível
+                  </th>
+                  <th className="text-left px-4 py-4 text-xs font-semibold text-muted-foreground uppercase tracking-wide hidden lg:table-cell">
+                    Status
+                  </th>
+                  <th className="text-left px-4 py-4 text-xs font-semibold text-muted-foreground uppercase tracking-wide hidden lg:table-cell">
+                    Inscritos
+                  </th>
+                  <th className="text-left px-4 py-4 text-xs font-semibold text-muted-foreground uppercase tracking-wide hidden md:table-cell">
+                    Treinos
+                  </th>
+                  <th className="px-4 py-4" />
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {plans.map((plan) => (
+                  <PlanRow key={plan.id} plan={plan} baseRoute={baseRoute} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+};
+
+// ── PlanRow ────────────────────────────────────────────────────────────────────
+
+interface PlanRowProps {
+  plan: TrainingPlanDto;
+  baseRoute: string;
+}
+
+const PlanRow = ({ plan, baseRoute }: PlanRowProps) => (
+  <tr className="hover:bg-secondary/30 transition-colors group">
+    <td className="px-6 py-4">
+      <div>
+        <p className="font-medium text-foreground line-clamp-1">{plan.name}</p>
+        <p className="text-xs text-muted-foreground mt-0.5 hidden md:block">
+          {TrainingObjectiveLabel[plan.objective]}
+        </p>
+        <div className="flex flex-wrap gap-1.5 mt-1.5 md:hidden">
+          <span className={`px-2 py-0.5 rounded-full text-xs border ${levelColors[plan.level]}`}>
+            {TrainingLevelLabel[plan.level]}
+          </span>
+          <span
+            className={`px-2 py-0.5 rounded-full text-xs border ${
+              plan.status === 1
+                ? "bg-emerald-500/10 text-emerald-400 border-emerald-500/30"
+                : "bg-secondary text-muted-foreground border-border"
+            }`}
+          >
+            {plan.status === 1 ? "Ativo" : "Inativo"}
+          </span>
+        </div>
+      </div>
+    </td>
+    <td className="px-4 py-4 hidden md:table-cell">
+      <span className={`px-2.5 py-1 rounded-full text-xs font-medium border ${levelColors[plan.level]}`}>
+        {TrainingLevelLabel[plan.level]}
+      </span>
+    </td>
+    <td className="px-4 py-4 hidden lg:table-cell">
+      <span
+        className={`px-2.5 py-1 rounded-full text-xs font-medium border ${
+          plan.status === 1
+            ? "bg-emerald-500/10 text-emerald-400 border-emerald-500/30"
+            : "bg-secondary text-muted-foreground border-border"
+        }`}
+      >
+        {plan.status === 1 ? "Ativo" : "Inativo"}
+      </span>
+    </td>
+    <td className="px-4 py-4 hidden lg:table-cell">
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <Users className="w-3.5 h-3.5" />
+        <span>
+          {plan.activeSubscriberCount} ativo{plan.activeSubscriberCount !== 1 ? "s" : ""} / {plan.subscriberCount} total
+        </span>
+      </div>
+    </td>
+    <td className="px-4 py-4 hidden md:table-cell">
+      <span className="text-xs text-muted-foreground">
+        {plan.workouts?.length ?? 0} treino{(plan.workouts?.length ?? 0) !== 1 ? "s" : ""}
+      </span>
+    </td>
+    <td className="px-4 py-4 text-right">
+      <Link
+        to={`${baseRoute}/${plan.id}`}
+        className="inline-flex items-center gap-1 text-xs text-muted-foreground group-hover:text-primary transition-colors"
+      >
+        Gerenciar <ChevronRight className="w-3 h-3" />
+      </Link>
+    </td>
+  </tr>
+);
+
+export default ManagementTrainingPlansList;


### PR DESCRIPTION
Implements full training-plans functionality across backend and frontend.

Changes include:
- Backend: new domain entities (TrainingPlan, TrainingWorkout, TrainingWorkoutItem, UserTrainingPlan, UserTrainingProgress, UserTrainingWorkoutDailyLog), value objects (enums), EF mappings, repositories and implementations, DTOs, validators, and service ITrainingPlanService / TrainingPlanService with logic for creating, updating, activating/deactivating, subscribing, cancelling, marking progress and finishing daily workouts.
- API: TrainingPlansController exposing user, professional and admin endpoints for listing, management, subscription, progress and history.
- Persistence: new EF migrations and AppDbContext updates to persist training-plan related tables.
- Dependency injection: registers TrainingPlanService in application DI and updates infrastructure DI mappings.
- Frontend: adds API client and pages/components for listing, detail, management, history and current user plan, plus App.tsx updates to wire routes.

Purpose: provide end-to-end support for creating and managing training plans, user subscriptions, progress tracking and daily workout logs, with role-based endpoints for admins and professionals.